### PR TITLE
Fix the options for node-gpsd

### DIFF
--- a/providers/gpsd.js
+++ b/providers/gpsd.js
@@ -30,8 +30,7 @@ function Gpsd(options) {
       warn: console.warn,
       error: console.error
     },
-    emitraw: true,
-    parsejson: false
+    parse: false
   });
 
   this.listener.connect(function() {


### PR DESCRIPTION
node-gpsd version 0.2.1 supports only the 'parse' option, and neither 'emitraw' nor 'parsejson' are supported. Fix the used options in gpsd-provider accordingly.