### PR TITLE
Change / to return list of installed Bower Signal K user interfaces

### DIFF
--- a/lib/config/development.js
+++ b/lib/config/development.js
@@ -34,10 +34,6 @@ module.exports = function(app) {
 
     app.use(morgan('dev'));
 
-    debug('Registering route: ALL /');
-    app.all('/', function(req, res) {
-      res.json(config);
-    });
 
     debug('Registering route: /examples');
     app.use('/examples',  express.static(__dirname + '/../../examples'));

--- a/lib/config/production.js
+++ b/lib/config/production.js
@@ -30,9 +30,5 @@ module.exports = function(app) {
 
     app.use(morgan('combined'));
     app.use(errorhandler());
-    
-    app.all('/', function(req, res) {
-      res.json({ 'signalk ready': true });
-    });
   }
 };

--- a/lib/interfaces/bower.js
+++ b/lib/interfaces/bower.js
@@ -14,8 +14,36 @@
  * limitations under the License.
 */
 
+var debug = require('debug')('signalk:interfaces:bower');
+
 module.exports = function(app) {
   var express = require('express');
-  app.use('/bower_components',  express.static(__dirname + '/../../bower_components'));
-  app.use('/',  express.static(__dirname + '/../../bower_components'));
+  app.use('/bower_components', express.static(__dirname + '/../../bower_components'));
+  app.use('/', express.static(__dirname + '/../../bower_components'));
+  app.get('/', bowerIndex);
 };
+
+function bowerIndex(req, res, next) {
+  var result = '<ul>';
+  result += getBowerComponentNames().reduce(function(result, componentName) {
+    return result += '<li><a href="' + componentName + '">' + componentName + '</a></li>\n';
+  }, '');
+  result += '</ul>';
+  res.send(result);
+}
+
+function getBowerComponentNames() {
+  var bowerBaseDir = __dirname + '/../../bower_components/';
+  return require('fs').readdirSync(bowerBaseDir).reduce(function(result, dir) {
+    try {
+      var componentBowerInfo = require(bowerBaseDir + dir + '/bower.json');
+      if (componentBowerInfo.keywords &&
+        componentBowerInfo.keywords.indexOf('signalk-ui') >= 0) {
+        return result.concat(dir);
+      }
+    } catch (exception) {
+      debug("Unable to get bower info for " + dir);
+    }
+    return result;
+  }, []);
+}


### PR DESCRIPTION
I get feedback from people struggling to get Signal K server & user interfaces working.

Now that we are about to have Bonjour/mDNS for discovering Signal K http server the next step in the chain is getting a reasonable response from the server. Currently it serves the configuration file, which is fine for a developer, but not really useful for a beginner.

With this change the root serves a rudimentary list of installed UI components ready for use, so the user can start with a Safari, discover the server, discover the UI and end up on a screen that shows data from the server.

The list is not pretty, but better than `{ 'signalk ready': true }`.

Next step is to fetch the list of `signalk-ui` tagged bower components from Bower registry.
