### PR TITLE
Make mDNS optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ For getting live data from your NGT-1 you need to figure out what device path yo
 
 If you have your own n2k data file you can use that with `bin/n2k-from-file --n2kfilename your-file-name`.
 
-The server advertises itself via Bonjour. This means that Bonjour-aware software running in the same network can discover the Signal K server and access it. For example the server shows up in Safari at Bookmarks => Bonjour => Webpages.
+
+Bonjour support
+---------------
+
+Bonjour support is not activated by default, because it requires operating system support that is not present by default on all platforms. You can enable it by installing `mdns` with `npm install mdns` issued in the server's root folder. See also https://github.com/agnat/node_mdns#installation for more information.
+
+Once Bonjour is enabled the server advertises itself via Bonjour. This means that Bonjour-aware software running in the same network can discover the Signal K server and access it. For example the server shows up in Safari at Bookmarks => Bonjour => Webpages.
 
 You can disable Bonjour/mDNS by adding the entry `"mdns": false` to the config file. See `settings/volare-gpsd-settings.json` for example.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,7 +87,12 @@ Server.prototype.start = function() {
 
   if (_.isUndefined(app.config.settings.mdns) || app.config.settings.mdns ) {
     debug("Starting interface 'mDNS'");
-    app.interfaces['mdns'] = require('./mdns')(app);
+    try {
+      app.interfaces['mdns'] = require('./mdns')(app);
+    } catch (ex) {
+      debug("Could not start mDNS:" + ex);
+
+    }
   } else {
     debug("Interface 'mDNS' was disabled in configuration");
   }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "express-namespace": "^0.1.1",
     "flatmap": "0.0.3",
     "lodash": "^2.4.1",
-    "mdns": "^2.2.8",
     "minimist": "^1.1.0",
     "morgan": "^1.5.0",
     "n2k-signalk": "signalk/n2k-signalk",


### PR DESCRIPTION
Because mDNS/Bonjour support may not be present we can not keep mdns as a hard dependency. Instead document the manual installation process and make code recover from missing dependency while keeping the 'enabled by default' behaviour.

Closes #40.