### PR TITLE
Raw logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "signalk-multiplexer": "signalk/signalk-multiplexer-node",
     "stream-throttle": "^0.1.3",
     "through": ">=2.2.7 <3",
+    "winston": "^1.0.0",
     "ws": "^0.4.32"
   },
   "devDependencies": {

--- a/providers/liner.js
+++ b/providers/liner.js
@@ -16,6 +16,26 @@
 
 var Transform = require('stream').Transform;
 
+var winston = require('winston'),
+  path = require('path'),
+  transports = [];
+
+transports.push(new winston.transports.DailyRotateFile({
+  name: 'file',
+  datePattern: '.yyyy-MM-ddTHH',
+  filename: "/tmp/log_file.log",
+  json: false,
+  formatter: function(options) {
+    // Return string will be passed to logger.
+    return new Date().getTime() + ';' + options.message;
+  }
+
+}));
+
+var logger = new winston.Logger({
+  transports: transports
+});
+
 function Liner() {
   Transform.call(this, {
     objectMode: true
@@ -36,13 +56,18 @@ Liner.prototype._transform = function(chunk, encoding, done) {
     console.error("Are you sure you are using the correct line terminator? Not going to handle lines longer than 2048 chars.");
     this._lastLineData = '';
   }
-  lines.forEach(this.push.bind(this));
+  var that = this;
+  lines.forEach(function(line) {
+    logger.info(line);
+    that.push(line);
+  });
 
   done();
 }
 
 Liner.prototype._flush = function(done) {
   if (this._lastLineData) {
+    logger.info(line);
     this.push(this._lastLineData);
   }
   this._lastLineData = null;

--- a/providers/liner.js
+++ b/providers/liner.js
@@ -16,30 +16,14 @@
 
 var Transform = require('stream').Transform;
 
-var winston = require('winston'),
-  path = require('path'),
-  transports = [];
 
-transports.push(new winston.transports.DailyRotateFile({
-  name: 'file',
-  datePattern: '.yyyy-MM-ddTHH',
-  filename: "/tmp/log_file.log",
-  json: false,
-  formatter: function(options) {
-    // Return string will be passed to logger.
-    return new Date().getTime() + ';' + options.message;
-  }
-
-}));
-
-var logger = new winston.Logger({
-  transports: transports
-});
-
-function Liner() {
+function Liner(options) {
   Transform.call(this, {
     objectMode: true
   });
+  if (options.rawlogging) {
+    this.logger = createLogger(options.logdir, options.discriminator);
+  }
 }
 
 require('util').inherits(Liner, Transform);
@@ -56,22 +40,55 @@ Liner.prototype._transform = function(chunk, encoding, done) {
     console.error("Are you sure you are using the correct line terminator? Not going to handle lines longer than 2048 chars.");
     this._lastLineData = '';
   }
-  var that = this;
-  lines.forEach(function(line) {
-    logger.info(line);
-    that.push(line);
-  });
+
+  lines.forEach(outputLine.bind(this));
 
   done();
 }
 
+function outputLine(line) {
+  if (typeof this.logger != 'undefined') {
+    try {
+      this.logger.info(line);
+    } catch (ex) {
+      console.error(ex);
+    }
+  }
+  this.push(line);
+}
+
 Liner.prototype._flush = function(done) {
   if (this._lastLineData) {
-    logger.info(line);
-    this.push(this._lastLineData);
+    outputLine.call(this, this._lastLineData);
   }
+
   this._lastLineData = null;
   done();
+}
+
+function createLogger(logdir, discriminator) {
+  var notEmptyDiscriminator = discriminator || "";
+  var winston = require('winston'),
+    transports = [];
+
+  var logfilename = require('path').join(
+    (logdir.indexOf('/') === 0 ? '' : (__dirname + "/../") ) +
+    logdir +
+    "/signalk-rawdata.log");
+  transports.push(new winston.transports.DailyRotateFile({
+    name: 'file',
+    datePattern: '.yyyy-MM-ddTHH',
+    filename: logfilename,
+    json: false,
+    formatter: function(options) {
+      // Return string will be passed to logger.
+      return new Date().getTime() + ';' + notEmptyDiscriminator + ';' + options.message;
+    }
+  }));
+
+  return new winston.Logger({
+    transports: transports
+  });
 }
 
 

--- a/settings/multiple-sources.json
+++ b/settings/multiple-sources.json
@@ -1,0 +1,80 @@
+{
+  "vessel": {
+    "name": "Multiple Sources",
+    "brand": "",
+    "type": "",
+    "uuid": "10101011",
+
+    "dimensions": {
+      "length": 7,
+      "width": 2.5,
+      "mast": 10,
+      "depthTransducer": 0.5,
+      "keel": 1.5
+    }
+  },
+
+  "pipedProviders": [{
+    "id": "nmeaFromFile",
+    "pipeElements": [{
+      "type": "providers/filestream",
+      "options": {
+        "filename": "samples/plaka.log"
+      },
+      "optionMappings": [{
+        "fromAppProperty": "argv.nmeafilename",
+        "toOption": "filename"
+      }]
+    }, {
+      "type": "providers/throttle",
+      "options": {
+        "rate": 500
+      }
+    }, {
+      "type": "providers/liner",
+         "options": {
+           "rawlogging" : true,
+           "logdir": "logs",
+           "discriminator": "1"
+         }
+
+    }, {
+      "type": "providers/nmea0183-signalk",
+      "optionMappings": [{
+        "fromAppProperty": "selfId",
+        "toOption": "selfId"
+      }, {
+        "fromAppProperty": "selfType",
+        "toOption": "selfType"
+      }]
+    }]
+  }, {
+    "id": "n2kFromFile",
+    "pipeElements": [{
+      "type": "providers/filestream",
+      "options": {
+        "filename": "samples/aava-n2k.data"
+      },
+      "optionMappings": [{
+        "fromAppProperty": "argv.n2kfilename",
+        "toOption": "filename"
+      }]
+    }, {
+      "type": "providers/throttle",
+      "options": {
+        "rate": 500
+      }
+    }, {
+      "type": "providers/liner",
+         "options": {
+           "rawlogging" : true,
+           "logdir": "logs",
+           "discriminator": "2"
+         }      
+    }, {
+      "type": "providers/n2kAnalyzer"
+    }, {
+      "type": "providers/n2k-signalk"
+    }]
+  }]
+}


### PR DESCRIPTION
Implement a way to log the raw data received from input devices in a single, hourly rolling file with timestamps. This way the raw data can be played back in the order the data was received from the various input devices, in actual rate or speeded up/slowed down.

