### PR TITLE
Revert "make startup scripts more shell agnostic"

### DIFF
--- a/bin/actisense-serial-n2kd
+++ b/bin/actisense-serial-n2kd
@@ -1,3 +1,2 @@
-#!/bin/sh
+#!/bin/bash
 actisense-serial /dev/tty.usbserial-1FD34 | analyzer -json | tee >(n2kd)
-

--- a/bin/n2k-from-actisense
+++ b/bin/n2k-from-actisense
@@ -1,7 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
-SP=`readlink -f $0`
-DIR=`dirname $SP`
-cd $DIR/..
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $DIR/signalk-server -s ./settings/actisense-serial-settings.json $*
-

--- a/bin/n2k-from-file
+++ b/bin/n2k-from-file
@@ -1,7 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
-SP=`readlink -f $0`
-DIR=`dirname $SP`
-cd $DIR/..
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $DIR/signalk-server -s ./settings/aava-file-settings.json $*
-

--- a/bin/nmea-from-file
+++ b/bin/nmea-from-file
@@ -1,7 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
-SP=`readlink -f $0`
-DIR=`dirname $SP`
-cd $DIR/..
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 $DIR/signalk-server -s ./settings/volare-file-settings.json $*
-


### PR DESCRIPTION
Reverts SignalK/signalk-server-node#48

Wasn't quite os agnostic.