### PR TITLE
OS and shell independent way of finding path to signal-k executables.

### DIFF
--- a/bin/n2k-from-actisense
+++ b/bin/n2k-from-actisense
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-SP=`readlink -f $0`
-DIR=`dirname $SP`
+SP=`dirname $0`
+DIR=`cd  $SP;pwd`
 cd $DIR/..
 $DIR/signalk-server -s ./settings/actisense-serial-settings.json $*
 

--- a/bin/n2k-from-file
+++ b/bin/n2k-from-file
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-SP=`readlink -f $0`
-DIR=`dirname $SP`
+SP=`dirname $0`
+DIR=`cd  $SP;pwd`
 cd $DIR/..
 $DIR/signalk-server -s ./settings/aava-file-settings.json $*
 

--- a/bin/nmea-from-file
+++ b/bin/nmea-from-file
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-SP=`readlink -f $0`
-DIR=`dirname $SP`
+SP=`dirname $0`
+DIR=`cd  $SP;pwd`
 cd $DIR/..
 $DIR/signalk-server -s ./settings/volare-file-settings.json $*
 


### PR DESCRIPTION

this should work on mac osx, freebsd, and linux