### PR TITLE
Portable Scripts in ./bin

### DIFF
--- a/bin/actisense-serial-n2kd
+++ b/bin/actisense-serial-n2kd
@@ -1,2 +1,3 @@
-#!/bin/bash
+#!/bin/sh
+
 actisense-serial /dev/tty.usbserial-1FD34 | analyzer -json | tee >(n2kd)

--- a/bin/n2k-from-actisense
+++ b/bin/n2k-from-actisense
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/signalk-server -s ./settings/actisense-serial-settings.json $*
+DIR=`dirname $0`
+${DIR}/signalk-server -s ${DIR}/../settings/actisense-serial-settings.json $*

--- a/bin/n2k-from-file
+++ b/bin/n2k-from-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/signalk-server -s ./settings/aava-file-settings.json $*
+DIR=`dirname $0`
+${DIR}/signalk-server -s ${DIR}/../settings/aava-file-settings.json $*

--- a/bin/nmea-from-file
+++ b/bin/nmea-from-file
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-$DIR/signalk-server -s ./settings/volare-file-settings.json $*
+DIR=`dirname $0`
+${DIR}/signalk-server -s ${DIR}/../settings/volare-file-settings.json $*

--- a/bin/signalk-server
+++ b/bin/signalk-server
@@ -2,11 +2,11 @@
 
 /*
  * Copyright 2014-2015 Fabian Tollenaar <fabian@starting-point.nl>
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
 
  * Unless required by applicable law or agreed to in writing, software

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-server",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "An implementation of a [Signal K](http://signalk.github.io) server for boats.",
   "main": "index.js",
   "scripts": {
@@ -35,7 +35,7 @@
       "email": "teppo.kurki@iki.fi"
     }
   ],
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "engines": {
     "node": "v0.10.x"
   },


### PR DESCRIPTION
Per @lsoltero in #50, switch from bash to sh for scripts and remove bashisms.

Addresses a problem with relative path for settings files which only made it possible to call these scripts from the root of the project folder, i.e. `./bin/nmea-from-file`, but not from the `bin` directory as `./nmea-from-file` (or from any other path for that matter).

Also:
* Bump version to 0.1.20
* Use SPDX compatible license ID (Apache-2.0 vs Apache 2) see https://spdx.org/licenses/