### PR TITLE
Fixed a bug in REST interface

### DIFF
--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -19,7 +19,7 @@ module.exports = function(app) {
 
   var debug = require('debug')('signalk-server:interfaces:rest');
   var pathPrefix = '/signalk';
-  var apiPathPrefix = pathPrefix + '/v1/api';
+  var apiPathPrefix = pathPrefix + '/v1/api/';
 
   return {
     start: function() {

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -33,7 +33,7 @@ module.exports = function(app) {
           return res.json(data.vessels[self]);
         }
 
-        path = path.split('/');
+        path = path.length > 0 ? path.replace(/\/$/, '').split('/') : [];
 
         for(var i in path) {
           var p = path[i];


### PR DESCRIPTION
This PR fixes a small bug in the REST interface that causes 404s on every path after `/signalk/v1/api/`. 