### PR TITLE
Fix ENOENT if bower_components is missing

### DIFF
--- a/lib/interfaces/bower.js
+++ b/lib/interfaces/bower.js
@@ -14,7 +14,8 @@
  * limitations under the License.
 */
 
-var debug = require('debug')('signalk:interfaces:bower');
+var debug = require('debug')('signalk:interfaces:bower'),
+    fs = require('fs');
 
 
 module.exports = function(app) {
@@ -50,7 +51,15 @@ function bowerIndex(req, res, next) {
 
 function getBowerComponents() {
   var bowerBaseDir = __dirname + '/../../bower_components/';
-  return require('fs').readdirSync(bowerBaseDir).reduce(function(result, dir) {
+  var bowerFiles = [];
+
+  try {
+    bowerFiles = fs.readdirSync(bowerBaseDir);
+  } catch (exception) {
+    debug("No such directory:", bowerBaseDir);
+  }
+
+  return bowerFiles.reduce(function(result, dir) {
     try {
       var componentBowerInfo = require(bowerBaseDir + dir + '/bower.json');
       if (componentBowerInfo.keywords &&

--- a/lib/interfaces/index.js
+++ b/lib/interfaces/index.js
@@ -1,5 +1,5 @@
 require('fs').readdirSync(__dirname + '/').forEach(function(file) {
-  if (file.match(/.+\.js/g) !== null && file !== 'index.js') {
+  if (file.match(/.+\.js$/g) !== null && file !== 'index.js') {
     var name = file.replace('.js', '');
     exports[name] = require('./' + file);
   }


### PR DESCRIPTION
Currently, if after installing signalk-server-node - but before running
any of the `bower install` commands - you open `localhost:3000` in a
browser window, you'll see a rather uninviting error. This makes sure
that you see the rather uninviting "Signal K Server" empty page instead.

Also, a minor edit to the regex in lib/interfaces/index.js which
requires and exports files in that directory. It only checked for the
existence of .js in filenames, now it checks for files ending in .js.
This is important if you use an editor like vim which creates .swp
files.