### PR TITLE
Support Installation behind a Reverse Proxy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "signalk-server-node",
   "main": "index.js",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "homepage": "https://github.com/SignalK/signalk-server-node",
   "authors": [
     "Fabian Tollenaar <fabian@starting-point.nl>"

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -49,15 +49,17 @@ module.exports = function(app) {
         return res.json(last);
       });
 
-      //TODO make exposed port configurable, as we have a reverse proxy in front of us and what we report may be different
-      //from the port node is listening on
       app.get(pathPrefix, function(req, res) {
+        var host = getHostname(app.config);
+        var port = getPort(app.config);
+        port = (port === '' || port === 80) ? '' : ':' + port;
+
         res.json({
           'endpoints': {
             'v1': {
               'version': '1.alpha1',
-              'signalk-http': 'http://' + getHostname(app.config)+ (app.config.port === 80 ? '' : ':' + app.config.port) + '/signalk/v1/api',
-              'signalk-ws': 'http://' + getHostname(app.config)+ (app.config.port === 80 ? '' : ':' + app.config.port) + '/signalk/v1/stream'
+              'signalk-http': 'http://' + host + port + '/signalk/v1/api',
+              'signalk-ws': 'http://' + host + port + '/signalk/v1/stream'
             }
           }
         });
@@ -74,7 +76,9 @@ module.exports = function(app) {
 };
 
 function getHostname(config) {
-  if (config.hostname) {
+  if(config.settings.proxy_host) {
+    return config.settings.proxy_host;
+  } else if(config.hostname) {
     return config.hostname;
   }
   try {
@@ -82,4 +86,14 @@ function getHostname(config) {
   } catch(ex) {
     return "hostname_not_available";
   }
+}
+
+function getPort(config) {
+  console.log(config);
+  if(config.settings.proxy_port) {
+    return config.settings.proxy_port;
+  } else if(config.port) {
+    return config.port;
+  }
+  return '';
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-server",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "An implementation of a [Signal K](http://signalk.github.io) server for boats.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Adds two new config options for the settings file:

* `proxy_host`
* `proxy_port`

Use these to advertise the hostname and port of the proxy that the
Signal K server is running behind. This way, the endpoints reported at
the `/signalk` URL will be correct.