### PR TITLE
Fix path handling in cli.js

### DIFF
--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -24,7 +24,9 @@ module.exports = function(app) {
       return app.overrides.settings;
     }
 
-    return argv.s || './settings/settings.json';
+    var settingsFile = argv.s || 'settings/settings.json';
+
+    return path.join(app.config.appPath, settingsFile);
   }
 
   if(app.overrides.settings !== null && typeof app.overrides.settings === 'object') {
@@ -33,7 +35,7 @@ module.exports = function(app) {
   } else {
     app.__argv      = process.argv.slice(2);
     app.argv        = require('minimist')(app.__argv);
-    var settings    = path.join(process.cwd(), getSettingsFilename(app.argv));
+    var settings    = getSettingsFilename(app.argv);
 
     debug("Using settings file: " + settings);
 
@@ -45,7 +47,7 @@ module.exports = function(app) {
     }
 
     try {
-      app.config.defaults = require(path.join(process.cwd(), 'settings/defaults.json'));
+      app.config.defaults = require('../../settings/defaults.json');
     } catch(e) {
       console.error("No settings/defaults.json available")
     }

--- a/settings/settings.json
+++ b/settings/settings.json
@@ -1,0 +1,1 @@
+volare-file-settings.json


### PR DESCRIPTION
This corrects several issues in cli.js where paths were not handled
properly.

Also, adding a symlink to volare-file-settings.json to make the default
case of running bin/signalk-server work correctly. This is not ideal,
it would be much better to have a default settings file which didn't
actually do anything.

However, with this commit it is possible to use pm2 to run the server
as a service (and without elevated permissions).

TODO: Configure server to drop permissions if started as root