### PR TITLE
Mdns proxy support

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -27,6 +27,9 @@ module.exports = function(app) {
     , env           = app.env = process.env
   ;
 
+  config.getExternalHostname = getExternalHostname.bind(config, config);
+  config.getExternalPort = getExternalPort.bind(config, config);
+
   app.event = new EventEmitter();
   app.use(cors());
 
@@ -55,8 +58,31 @@ module.exports = function(app) {
 
   debug("Config - appPath: " + config.appPath);
   debug("Config - port: " + config.port);
-  
+
   require('./development')(app);
   require('./production')(app);
   require('./cli')(app);
 };
+
+function getExternalHostname(config) {
+  if(config.settings.proxy_host) {
+    return config.settings.proxy_host;
+  } else if(config.hostname) {
+    return config.hostname;
+  }
+  try {
+    return require('os').hostname();
+  } catch(ex) {
+    return "hostname_not_available";
+  }
+}
+
+function getExternalPort(config) {
+  console.log(config);
+  if(config.settings.proxy_port) {
+    return config.settings.proxy_port;
+  } else if(config.port) {
+    return config.port;
+  }
+  return '';
+}

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -50,8 +50,8 @@ module.exports = function(app) {
       });
 
       app.get(pathPrefix, function(req, res) {
-        var host = getHostname(app.config);
-        var port = getPort(app.config);
+        var host = app.config.getExternalHostname();
+        var port = app.config.getExternalPort();
         port = (port === '' || port === 80) ? '' : ':' + port;
 
         res.json({
@@ -74,26 +74,3 @@ module.exports = function(app) {
     }
   };
 };
-
-function getHostname(config) {
-  if(config.settings.proxy_host) {
-    return config.settings.proxy_host;
-  } else if(config.hostname) {
-    return config.hostname;
-  }
-  try {
-    return require('os').hostname();
-  } catch(ex) {
-    return "hostname_not_available";
-  }
-}
-
-function getPort(config) {
-  console.log(config);
-  if(config.settings.proxy_port) {
-    return config.settings.proxy_port;
-  } else if(config.port) {
-    return config.port;
-  }
-  return '';
-}

--- a/lib/mdns.js
+++ b/lib/mdns.js
@@ -19,14 +19,14 @@ module.exports = function mdns(app) {
 
   var _, uuid, mdns, ad, types, serviceId, config, debug, service, services, ads, ad, type, meta;
 
-  _             = require('lodash');
-  debug         = require('debug')('signalk-server:interfaces:mdns');
-  config        = app.config;
-  types         = [];
-  ads           = [];
-  mdns          = require('mdns');
-  uuid          = require('node-uuid').v4;
-  serviceId     = String(uuid()).slice(0, 7);
+  _ = require('lodash');
+  debug = require('debug')('signalk-server:interfaces:mdns');
+  config = app.config;
+  types = [];
+  ads = [];
+  mdns = require('mdns');
+  uuid = require('node-uuid').v4;
+  serviceId = String(uuid()).slice(0, 7);
 
   if (typeof config.settings.mdns != 'undefined' && !config.settings.mdns) {
     debug("Mdns disabled by configuration");
@@ -44,22 +44,28 @@ module.exports = function mdns(app) {
     vessel_type: (_.isObject(config.settings.vessel) && typeof config.settings.vessel.type === 'string') ? config.settings.vessel.type : ''
   };
 
-  if(_.isObject(config.settings.vessel) && typeof config.settings.vessel.mmsi === 'string' && config.settings.vessel.mmsi.trim().length > 0) {
+  if (_.isObject(config.settings.vessel) && typeof config.settings.vessel.mmsi === 'string' && config.settings.vessel.mmsi.trim().length > 0) {
     meta.vessel_mmsi = config.settings.vessel.mmsi;
     meta.vessel_uuid = meta.vessel_mmsi;
-  } else if(_.isObject(config.settings.vessel) && typeof config.settings.vessel.uuid === 'string' && config.settings.vessel.uuid.trim().length > 0) {
+  } else if (_.isObject(config.settings.vessel) && typeof config.settings.vessel.uuid === 'string' && config.settings.vessel.uuid.trim().length > 0) {
     meta.vessel_mmsi = config.settings.vessel.uuid;
     meta.vessel_uuid = meta.vessel_mmsi;
   }
 
-  types.push({ type: mdns['tcp']('http'), port: app.config.port });
+  types.push({
+    type: mdns['tcp']('http'),
+    port: app.config.port
+  });
 
-  for(var key in app.interfaces) {
-    if(_.isObject(app.interfaces[key]) && _.isObject(app.interfaces[key].mdns)) {
+  for (var key in app.interfaces) {
+    if (_.isObject(app.interfaces[key]) && _.isObject(app.interfaces[key].mdns)) {
       service = app.interfaces[key].mdns;
 
-      if('tcp'.indexOf(service.type) !== -1 && service.name.charAt(0) === '_') {
-        types.push({ type: mdns[service.type](service.name), port: service.port });
+      if ('tcp'.indexOf(service.type) !== -1 && service.name.charAt(0) === '_') {
+        types.push({
+          type: mdns[service.type](service.name),
+          port: service.port
+        });
       } else {
         debug('Not advertising mDNS service for interface: ' + key);
         debug('mDNS service type should be TCP or HTTP, and the name should start with "_".');
@@ -68,10 +74,12 @@ module.exports = function mdns(app) {
   }
 
 
-  for(var i in types) {
+  for (var i in types) {
     type = types[i];
     debug("Starting mDNS ad:" + type.type + " " + type.port);
-    ad = new mdns.Advertisement(type.type, Number(type.port), { txtRecord: meta });
+    ad = new mdns.Advertisement(type.type, Number(type.port), {
+      txtRecord: meta
+    });
     ad.start();
     ads.push(ad);
   }

--- a/lib/mdns.js
+++ b/lib/mdns.js
@@ -76,9 +76,10 @@ module.exports = function mdns(app) {
 
   for (var i in types) {
     type = types[i];
-    debug("Starting mDNS ad:" + type.type + " " + type.port);
-    ad = new mdns.Advertisement(type.type, Number(type.port), {
-      txtRecord: meta
+    debug("Starting mDNS ad:" + type.type + " " + app.config.getExternalHostname() + ":" + app.config.getExternalPort());
+    ad = new mdns.Advertisement(type.type, Number(app.config.getExternalPort()), {
+      txtRecord: meta,
+      host: app.config.getExternalHostname()
     });
     ad.start();
     ads.push(ad);


### PR DESCRIPTION
Use the same logic to determine the host and port that are used
in mDNS/dns-sd advertisement and /signalk endpoints.