### PR TITLE
Fix the REST API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Start the server with
 bin/nmea-from-file
 ```
 
-This will start the server with a sample configuration file and the server will start playing back set of [NMEA 0183](http://en.wikipedia.org/wiki/NMEA_0183) data from file. The data is available immediately via the REST interface at http://localhost:3000/signalk/api/v1/.
+This will start the server with a sample configuration file and the server will start playing back set of [NMEA 0183](http://en.wikipedia.org/wiki/NMEA_0183) data from file. The data is available immediately via the REST interface at http://localhost:3000/signalk/v1/api/.
 
 A simple way to connect to the WebSocket interface from the command line is to install wscat and use that:
 ```

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -21,8 +21,9 @@ module.exports = function(app) {
   var express = require('express');
 
   var pathPrefix = '/signalk';
-  var apiPathPrefix = pathPrefix + '/v1/api/';
-  var streamPath = pathPrefix + '/stream'
+  var versionPrefix = '/v1';
+  var apiPathPrefix = pathPrefix + versionPrefix + '/api/';
+  var streamPath = pathPrefix + versionPrefix + '/stream';
 
   return {
     start: function() {

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -58,7 +58,7 @@ module.exports = function(app) {
           'endpoints': {
             'v1': {
               'version': '1.alpha1',
-              'signalk-http': 'http://' + host + port + '/signalk/v1/api',
+              'signalk-http': 'http://' + host + port + apiPathPrefix,
               'signalk-ws': 'http://' + host + port + '/signalk/v1/stream'
             }
           }

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -22,6 +22,7 @@ module.exports = function(app) {
 
   var pathPrefix = '/signalk';
   var apiPathPrefix = pathPrefix + '/v1/api/';
+  var streamPath = pathPrefix + '/stream'
 
   return {
     start: function() {
@@ -59,7 +60,7 @@ module.exports = function(app) {
             'v1': {
               'version': '1.alpha1',
               'signalk-http': 'http://' + host + port + apiPathPrefix,
-              'signalk-ws': 'http://' + host + port + '/signalk/v1/stream'
+              'signalk-ws': 'http://' + host + port + streamPath
             }
           }
         });

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -55,12 +55,17 @@ module.exports = function(app) {
         var port = app.config.getExternalPort();
         port = (port === '' || port === 80) ? '' : ':' + port;
 
+        var protocol = 'http://';
+        if (app.config.settings.ssl) {
+          protocol = 'https://';
+        }
+
         res.json({
           'endpoints': {
             'v1': {
               'version': '1.alpha1',
-              'signalk-http': 'http://' + host + port + apiPathPrefix,
-              'signalk-ws': 'http://' + host + port + streamPath
+              'signalk-http': protocol + host + port + apiPathPrefix,
+              'signalk-ws': protocol + host + port + streamPath
             }
           }
         });


### PR DESCRIPTION
Fixes the inconsistencies between documentation, URLs advertised at the top level /signalk/ and the actual endpoints.

The SSL setting should be also handled differently in the mDNS advertisements as now we simply end up always trying to use HTTP, but I still didn't do the homework of actually reading about how exactly it works, so don't see an obvious way to do it.