### PR TITLE
Settings file from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Now what? Consumers!
 
 Once you have the data streams in place you probably want to use the data or at least see it in a nice format. See [Consumers](https://github.com/SignalK/signalk-server-node/blob/master/CONSUMERS.md) for details.
 
+Configuration
+=============
+
+Please take a look at the different settings files in the `settings` directory.
+
+You can specify the settings file via command line with `bin/signalk-server -s <path-to-your-settings-file>`.
+
+You can also configure the path to the settings file with environment parameter `SIGNALK_NODE_SETTINGS`.
+
 Real Inputs
 ---------------
 To hook the server up to your real inputs you need to create a configuration file that connects to your input source and applies the relevant parsers / converters in the provider pipeline.
@@ -62,6 +71,7 @@ Supported inputs & formats
 - GPSD
 
 Please see [example settings files](https://github.com/SignalK/signalk-server-node/tree/master/settings).
+
 
 Bonjour support
 ---------------

--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -19,6 +19,11 @@ module.exports = function(app) {
   var debug  = require('debug')('signalk-server:config:cli');
 
   function getSettingsFilename(argv) {
+    if(process.env.SIGNALK_NODE_SETTINGS) {
+      debug('Settings filename was set in environment SIGNALK_NODE_SETTINGS, overriding all other options');
+      return path.resolve(process.env.SIGNALK_NODE_SETTINGS);
+    }
+
     if(app.overrides.settings && typeof app.overrides.settings === 'string') {
       debug('Settings filename was set using .settings(), overriding all other options');
       return path.join(app.config.appPath, app.overrides.settings);


### PR DESCRIPTION
Add the ability to specify the path to the settings file with SIGNALK_NODE_SETTINGS environment variable.