### PR TITLE
Experimental providers branch, to improve error handling and prepare moving providers out of codebase and onto NPM

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ Server.prototype.start = function() {
 
     startInterfaces(app);
     startMdns(app);
-    app.providers = require('./pipedproviders')(app).start();
+    app.providers = require('./providers')(app).start();
 
     var SD_LISTEN_FDS_START = 3
     var port = process.env.LISTEN_FDS > 0 ? {fd: SD_LISTEN_FDS_START} : app.config.port;

--- a/lib/pipedproviders.js
+++ b/lib/pipedproviders.js
@@ -71,6 +71,7 @@ module.exports = function(app) {
     var nmea0183Listener = function(sentence) {
       app.signalk.emit('nmea0183', sentence);
     }
+    
     if (app.config.settings.pipedProviders) {
       return app.config.settings.pipedProviders.map(function(providerConfig) {
         return createPipedProvider(providerConfig, nmea0183Listener);

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -74,7 +74,13 @@ module.exports = function (app) {
   }
 
   function initProvider (provider, nmea0183Listener) {
-    let Module = new provider.Module(provider.config)
+    let Module
+
+    try {
+      Module = new provider.Module(provider.config)
+    } catch (e) {
+      throw new Error(`Provider "${provider.name}" has an invalid API (can't be created using "new")`)
+    }
 
     if (typeof Module.on !== 'function') {
       return Module

--- a/lib/providers.js
+++ b/lib/providers.js
@@ -1,0 +1,163 @@
+'use strict'
+
+/*
+ * Copyright 2016 Fabian Tollenaar <fabian@decipher.industries>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const debug = require('debug')('signalk-experimental-providers')
+const deep = require('deep-get-set')
+
+module.exports = function (app) {
+
+  const API = {
+    start: startProviders
+  }
+
+  function parseConfig (config) {
+    Object.keys(config).forEach((key) => {
+      if (!config.hasOwnProperty(key)) {
+        return
+      }
+
+      if (!isOptionMapping(config[key])) {
+        return
+      }
+
+      const mapping = config[key]
+
+      if (mapping.source === 'app' && deep(app, mapping.property)) {
+        config[key] = deep(app, mapping.property)
+        return
+      }
+
+      if (mapping.source === 'argv' && deep(app, `argv.${mapping.property}`)) {
+        config[key] = deep(app, `argv.${mapping.property}`)
+        return
+      }
+    })
+
+    return config
+  }
+
+  function prepareProvider (provider) {
+    if (typeof provider === 'string' && provider.trim() !== '') {
+      provider = {
+        name: provider,
+        config: {}
+      }
+    } else if (isObject(provider) && typeof provider.name === 'string' && provider.name.trim() !== '') {
+      provider.config = parseConfig(provider.config)
+    }
+
+    try {
+      // provider.Module = require(provider.name) @TODO
+      provider.Module = require(`../providers/${provider.name}`)
+      provider.config.app = app
+    } catch (e) {
+      debug(`Error requiring provider module: ${e.message}`)
+      throw new Error(`Provider ${provider.name} coudn't be found. Did you run 'npm install ${provider.name} --save'?`)
+    }
+
+    return provider
+  }
+
+  function initProvider (provider, nmea0183Listener) {
+    let Module = new provider.Module(provider.config)
+
+    if (typeof Module.on !== 'function') {
+      return Module
+    }
+
+    Module.on('nmea0183', nmea0183Listener)
+
+    Module.on('error', (err) => {
+      debug(`${provider.name} hit an error: ${err.message}`)
+      debug('Killing all providers and restarting the pipeline')
+
+      if (Array.isArray(app.providers) && app.providers.length > 0) {
+        app.providers.forEach(M => {
+          if (isObject(M) && typeof M.removeAllListeners === 'function') {
+            M.removeAllListeners()
+          }
+
+          M = null
+        })
+      }
+
+      if (isObject(Module) && typeof Module.removeAllListeners === 'function') {
+        Module.removeAllListeners()
+      }
+
+      Module = null
+      app.providers = API.start()
+    })
+
+    Module.on('data', (delta) => {
+      if (!isObject(delta) || typeof delta.updates === 'undefined') {
+        return
+      }
+
+      if (typeof delta.context === 'undefined') {
+        delta.context = `vessels.${app.selfId}`
+      }
+
+      delta.updates.forEach((update) => {
+        update.source.label = provider.name
+
+        if (!update.timestamp) {
+          update.timestamp = new Date().toISOString()
+        }
+      })
+
+      app.signalk.addDelta(delta)
+    })
+
+    return Module
+  }
+
+  function startProviders () {
+    if (!Array.isArray(app.config.settings.experimentalProviders) || app.config.settings.experimentalProviders.length === 0) {
+      console.warn('Warning: no providers found in the config')
+      return []
+    }
+
+    const Modules = []
+
+    app.config.settings.experimentalProviders.map((provider) => {
+      Modules.push(initProvider(prepareProvider(provider), (sentence) => {
+        app.signalk.emit('nmea0183', sentence)
+      }))
+    })
+
+    Modules.forEach((Module, index) => {
+      if (typeof Modules[index + 1] !== 'undefined') {
+        Module.pipe(Modules[index + 1])
+      }
+    })
+
+    return Modules
+  }
+
+  return API
+
+}
+
+function isObject(mixed) {
+  return (typeof mixed === 'object' && mixed !== null)
+}
+
+function isOptionMapping(mixed) {
+  return (isObject(mixed) && typeof mixed.source === "string" && typeof mixed.source.trim() !== "")
+}

--- a/providers/filestream.js
+++ b/providers/filestream.js
@@ -6,7 +6,7 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
- 
+
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,8 +41,8 @@ FileStream.prototype.pipe = function(pipeTo) {
 
 FileStream.prototype.startStream = function() {
   if (this.keepRunning) {
-    this.filestream = require('fs').createReadStream(path.join(__dirname, '..', this.options.filename));
-    this.filestream.on('end', this.startStream.bind(this));
+    this.filestream = require('fs').createReadStream(path.join(__dirname, '..', this.options.filename))
+    this.filestream.on('end', this.startStream.bind(this))
     this.filestream.pipe(this.endIgnoringPassThrough)
   }
 }

--- a/providers/test-caught-error.js
+++ b/providers/test-caught-error.js
@@ -1,0 +1,22 @@
+var Transform = require('stream').Transform;
+
+function ToSignalK(options) {
+  Transform.call(this, {
+    objectMode: true
+  })
+
+  this.start = Date.now()
+}
+
+require('util').inherits(ToSignalK, Transform);
+
+ToSignalK.prototype._transform = function(chunk, encoding, done) {
+  if ((Date.now() - this.start) > 10000) {
+    return done(new Error('TEST CAUGHT ERROR'))
+  }
+
+  this.push(chunk)
+  done()
+}
+
+module.exports = ToSignalK;

--- a/providers/test-error.js
+++ b/providers/test-error.js
@@ -1,0 +1,22 @@
+var Transform = require('stream').Transform;
+
+function ToSignalK(options) {
+  Transform.call(this, {
+    objectMode: true
+  })
+
+  this.start = Date.now()
+}
+
+require('util').inherits(ToSignalK, Transform);
+
+ToSignalK.prototype._transform = function(chunk, encoding, done) {
+  if ((Date.now() - this.start) > 10000) {
+    return done(new Error('TEST ERROR'))
+  }
+
+  this.push(chunk)
+  done()
+}
+
+module.exports = ToSignalK;

--- a/providers/test-error.js
+++ b/providers/test-error.js
@@ -12,7 +12,8 @@ require('util').inherits(ToSignalK, Transform);
 
 ToSignalK.prototype._transform = function(chunk, encoding, done) {
   if ((Date.now() - this.start) > 10000) {
-    return done(new Error('TEST ERROR'))
+    throw new new Error('TEST ERROR')
+    // return done(new Error('TEST ERROR'))
   }
 
   this.push(chunk)

--- a/providers/test-uncaught-error.js
+++ b/providers/test-uncaught-error.js
@@ -12,8 +12,7 @@ require('util').inherits(ToSignalK, Transform);
 
 ToSignalK.prototype._transform = function(chunk, encoding, done) {
   if ((Date.now() - this.start) > 10000) {
-    throw new new Error('TEST ERROR')
-    // return done(new Error('TEST ERROR'))
+    throw new Error('TEST UNCAUGHT ERROR')
   }
 
   this.push(chunk)

--- a/settings/volare-file-settings.json
+++ b/settings/volare-file-settings.json
@@ -1,59 +1,35 @@
 
 {
   "vessel": {
-    "name"  : "Volare",
-    "brand" : "Friendship",
-    "type"  : "22",
-    "uuid"  : "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d",
-    
-    "dimensions": {
-      "length": 7,
-      "width": 2.5,
-      "mast": 10,
-      "depthTransducer": 0.5,
-      "keel": 1.5 
-    }
+    "name": "Volare",
+    "brand": "Friendship",
+    "type": "22",
+    "uuid": "urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d"
   },
 
-  "interfaces": {},
-  
-  "pipedProviders": [{
-    "id": "nmeaFromFile",
-    "pipeElements": [
-       { 
-         "type": "providers/filestream",
-         "options": {
-           "filename": "samples/plaka.log"
-         },
-         "optionMappings": [
-           {
-             "fromAppProperty": "argv.nmeafilename",
-             "toOption": "filename"
-           }
-         ]
-       },
-       { 
-         "type": "providers/throttle",
-         "options": {
-            "rate": 500
-         }
-       },       
-       {
-         "type": "providers/liner"
-       },
-       {
-          "type": "providers/nmea0183-signalk",
-          "optionMappings": [
-            {
-             "fromAppProperty": "selfId",
-             "toOption": "selfId"
-            },
-            {
-             "fromAppProperty": "selfType",
-             "toOption": "selfType"
-            }
-          ]
-       }               
-    ]
-  }]
+  "experimentalProviders": [
+    {
+      "name": "filestream",
+      "config": {
+        "filename": "samples/plaka.log"
+      }
+    },
+
+    {
+      "name": "throttle",
+      "config": {
+        "rate": 500
+      }
+    },
+
+    "liner",
+
+    {
+      "name": "nmea0183-signalk",
+      "config": {
+        "selfId": { "source": "app", "property": "selfId" },
+        "selfType": { "source": "app", "property": "selfType" }
+      }
+    }
+  ]
 }


### PR DESCRIPTION
*DO NOT PULL YET*

This branch includes the following changes:
- Error handling on piped providers (see also https://github.com/SignalK/signalk-server-node/issues/30). Assuming the provider handles errors correctly (i.e. catches the error and emits an error event) the pipeline now catches the error, removes all listeners to all providers, NULLifies them, dereferences them in order to allow them to be GC'ed and restarts the pipeline. 
- Changes to configuration, related to next point
- Prepared code to move all providers out of codebase and onto NPM

The first point requires thorough review and testing. The last two points are up for discussion. I'm of the opinion that providers should not live in our codebase but on NPM, making it easier for third parties to write providers (we do need to write some docs as to how to write a provider) and making this code more maintainable. Since I was working on that anyway, I cleaned up the config somewhat in a way that makes it a bit less verbose and nicer to look at (also in preparation for making the configuration user-editable using a UI).

Error handling on providers works assuming that all internal errors are caught and emitted as an error (either by calling `done(err)` in the `_transform` method or by calling `this.emit('error', err)`). Unhandeled errors in a provider causes an application crash. I'm looking for a solution, but so far haven't found one beyond writing proper providers. 