### PR TITLE
Output error on serial provider to console log

### DIFF
--- a/providers/serialport.js
+++ b/providers/serialport.js
@@ -53,7 +53,7 @@ SerialStream.prototype.start = function() {
     this.serial.pipe(this);
   }.bind(this));
 
-  this.serial.on('error', this.start.bind(this));
+  this.serial.on('error', function(x) {console.log(x)});
   this.serial.on('close', this.start.bind(this));
 };
 


### PR DESCRIPTION
In case of a problem on opening serial port, output an error to console log rather than just restarting.