### PR TITLE
Add provider for static Signal K WebSocket server

### DIFF
--- a/bin/signalk-from-ws
+++ b/bin/signalk-from-ws
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/signalk-server -s ./settings/moonchild-signalk-ws-settings.json $*

--- a/providers/signalk-ws.js
+++ b/providers/signalk-ws.js
@@ -29,13 +29,9 @@ function SignalKWs(options) {
   });
   this.selfHost = options.app.config.getExternalHostname() + ".";
   this.selfPort = options.app.config.getExternalPort();
-  this.remoteServers = {};
-  this.remoteServers[this.selfHost + ":" + this.selfPort] = {};
   this.signalkClient = new SignalK.Client();
   var url = "ws://" + options.host + ":" + options.port + options.path;
-  var that = this;
   var onConnect = function(connection) {
-    that.remoteServers[options.host + ":" + options.port] = {};
     debug("Connected to " + url);
     connection.subscribeAll();
   }

--- a/providers/signalk-ws.js
+++ b/providers/signalk-ws.js
@@ -19,7 +19,7 @@ var Transform = require('stream').Transform;
 
 var SignalK = require('signalk-client');
 
-var debug = require('debug')('signalk-server:providers:mdns-ws');
+var debug = require('debug')('signalk-server:providers:signalk-ws');
 
 var WebSocket = require('ws');
 var _object = require('lodash/object');

--- a/providers/signalk-ws.js
+++ b/providers/signalk-ws.js
@@ -22,7 +22,6 @@ var SignalK = require('signalk-client');
 var debug = require('debug')('signalk-server:providers:signalk-ws');
 
 var WebSocket = require('ws');
-var _object = require('lodash/object');
 
 function SignalKWs(options) {
   Transform.call(this, {

--- a/providers/signalk-ws.js
+++ b/providers/signalk-ws.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016 Ilker Temir <ilker@ilkertemir.com> based on code
+ * by Teppo Kurki <teppo.kurki@iki.fi>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Transform = require('stream').Transform;
+
+var SignalK = require('signalk-client');
+
+var debug = require('debug')('signalk-server:providers:mdns-ws');
+
+var WebSocket = require('ws');
+var _object = require('lodash/object');
+
+function SignalKWs(options) {
+  Transform.call(this, {
+    objectMode: true
+  });
+  this.selfHost = options.app.config.getExternalHostname() + ".";
+  this.selfPort = options.app.config.getExternalPort();
+  this.remoteServers = {};
+  this.remoteServers[this.selfHost + ":" + this.selfPort] = {};
+  this.signalkClient = new SignalK.Client();
+  var url = "ws://" + options.host + ":" + options.port + options.path;
+  var that = this;
+  var onConnect = function(connection) {
+    that.remoteServers[options.host + ":" + options.port] = {};
+    debug("Connected to " + url);
+    connection.subscribeAll();
+  }
+  var onDisconnect = function() {
+    debug("Disconnected from " + url);
+  }
+  var onError = function(err) {
+    debug("Error:" + err);
+  }
+  this.signalkClient.connectDeltaByUrl(url, this.push.bind(this), onConnect, onDisconnect, onError);
+}
+
+require('util').inherits(SignalKWs, Transform);
+
+SignalKWs.prototype._transform = function(chunk, encoding, done) {}
+
+module.exports = SignalKWs;

--- a/settings/moonchild-signalk-ws-settings.json
+++ b/settings/moonchild-signalk-ws-settings.json
@@ -1,0 +1,48 @@
+{
+        "vessel": {
+                "name"  : "Moonchild",
+                "brand" : "Catalina",
+                "type"  : "320",
+                "uuid"  : "self",
+
+                "dimensions": {
+                        "length": 9.9,
+                        "width": 3.6,
+                        "mast": 14.5,
+                        "depthTransducer": 0.6,
+                        "keel": 1.8
+                }
+        },
+    "mdns": true,
+	"interfaces": {
+    "rest": false,
+    "ws": true,
+    "bower": false,
+    "tcp": false,
+    "nmea-tcp": false
+  },
+
+  "pipedProviders": [{
+    "id": "SignalkWs",
+    "pipeElements": [
+       {
+         "type": "providers/signalk-ws",
+         "options": {
+           "host": "localhost",
+           "port": "1923",
+           "path": "/signalk/v1/stream"
+         },
+          "optionMappings": [
+            {
+             "fromAppProperty": "selfId",
+             "toOption": "selfId"
+            },
+            {
+             "fromAppProperty": "selfType",
+             "toOption": "selfType"
+            }
+          ]
+       }
+    ]
+  }]
+}


### PR DESCRIPTION
mdns-ws provides Signal K WebSocket server but only when they are advertised over mDNS. This is not suitable in all scenarios, for instance where multiple Signal K servers may be running on the same host and the Node server is used to multiplex them with other inputs like NMEA.

This commit introduces a new provider signalk-ws, that allows static Signal K server configurations.