### PR TITLE
Update mDNS TXT Record Population Logic

### DIFF
--- a/lib/mdns.js
+++ b/lib/mdns.js
@@ -14,44 +14,46 @@
  * limitations under the License.
 */
 
-module.exports = function mdns(app) {
-  'use strict';
+'use strict';
 
-  var _, uuid, mdns, ad, types, serviceId, config, debug, service, services, ads, ad, type, meta;
+let _ = require('lodash'),
+    debug = require('debug')('signalk-server:interfaces:mdns'),
+    mdns = require('mdns'),
+    uuid = require('node-uuid').v4;
 
-  _ = require('lodash');
-  debug = require('debug')('signalk-server:interfaces:mdns');
-  config = app.config;
-  types = [];
-  ads = [];
-  mdns = require('mdns');
-  uuid = require('node-uuid').v4;
-  serviceId = String(uuid()).slice(0, 7);
+function getConfigString(settingsObject, key) {
+  if(_.isObject(settingsObject) && typeof settingsObject[key] === 'string') {
+    return settingsObject[key].trim();
+  }
+
+  return '';
+}
+
+module.exports = function mdnsResponder(app) {
+  let config = app.config;
 
   if (typeof config.settings.mdns != 'undefined' && !config.settings.mdns) {
     debug("Mdns disabled by configuration");
     return;
   }
 
-  meta = {
+  let txtRecord = {
     server: config.name,
     version: config.version,
     //hardcoded out of master/slave, main/aux
     roles: "master, main",
     self: app.selfId,
-    vessel_name: (_.isObject(config.settings.vessel) && typeof config.settings.vessel.name === 'string') ? config.settings.vessel.name : '',
-    vessel_brand: (_.isObject(config.settings.vessel) && typeof config.settings.vessel.brand === 'string') ? config.settings.vessel.brand : '',
-    vessel_type: (_.isObject(config.settings.vessel) && typeof config.settings.vessel.type === 'string') ? config.settings.vessel.type : ''
+    vessel_name: getConfigString(config.settings.vessel, 'name'),
+    vessel_brand: getConfigString(config.settings.vessel, 'brand'),
+    vessel_type: getConfigString(config.settings.vessel, 'type'),
+    vessel_mmsi: getConfigString(config.settings.vessel, 'mmsi'),
+    vessel_uuid: getConfigString(config.settings.vessel, 'uuid')
   };
 
-  if (_.isObject(config.settings.vessel) && typeof config.settings.vessel.mmsi === 'string' && config.settings.vessel.mmsi.trim().length > 0) {
-    meta.vessel_mmsi = config.settings.vessel.mmsi;
-    meta.vessel_uuid = meta.vessel_mmsi;
-  } else if (_.isObject(config.settings.vessel) && typeof config.settings.vessel.uuid === 'string' && config.settings.vessel.uuid.trim().length > 0) {
-    meta.vessel_mmsi = config.settings.vessel.uuid;
-    meta.vessel_uuid = meta.vessel_mmsi;
-  }
+  // Strip all the null or empty props in txtRecord
+  txtRecord = _.pick(txtRecord, _.identity);
 
+  let types = [];
   types.push({
     type: app.config.settings.ssl ? mdns['tcp']('https') : mdns['tcp']('http'),
     port: app.config.port
@@ -59,7 +61,7 @@ module.exports = function mdns(app) {
 
   for (var key in app.interfaces) {
     if (_.isObject(app.interfaces[key]) && _.isObject(app.interfaces[key].mdns)) {
-      service = app.interfaces[key].mdns;
+      var service = app.interfaces[key].mdns;
 
       if ('tcp'.indexOf(service.type) !== -1 && service.name.charAt(0) === '_') {
         types.push({
@@ -73,19 +75,23 @@ module.exports = function mdns(app) {
     }
   }
 
-  var options = {
-    txtRecord: meta
-  }
-  var host = app.config.getExternalHostname();
+  let options = {
+    txtRecord: txtRecord
+  };
+
+  const host = app.config.getExternalHostname();
+
   if (host != require('os').hostname()) {
     options.host = host;
   }
-  debug(options)
 
+  debug(options);
+
+  let ads = [];
   for (var i in types) {
-    type = types[i];
-    debug("Starting mDNS ad:" + type.type + " " + app.config.getExternalHostname() + ":" + app.config.getExternalPort());
-    ad = new mdns.Advertisement(type.type, Number(app.config.getExternalPort()), options);
+    let type = types[i];
+    debug("Starting mDNS ad: " + type.type + " " + app.config.getExternalHostname() + ":" + app.config.getExternalPort());
+    let ad = new mdns.Advertisement(type.type, Number(app.config.getExternalPort()), options);
     ad.start();
     ads.push(ad);
   }
@@ -93,7 +99,7 @@ module.exports = function mdns(app) {
   return {
     stop: function() {
       ads.forEach(function(ad) {
-        debug('Stopping mdns advertisement..');
+        debug('Stopping mDNS advertisement...');
         ad.stop();
       })
     }


### PR DESCRIPTION
This updates the way vessel_uuid and vessel_mmsi are set in the mDNS TXT record fixing a bug where either both were set to the MMSI configured in the server or vessel_uuid was set to the MMSI and vessel_mmsi was set to the UUID.