### PR TITLE
Refuse to start with more than 400 ssl file permissions

### DIFF
--- a/bin/signalk-server
+++ b/bin/signalk-server
@@ -19,4 +19,8 @@
 var Server = require('../lib');
 var server = new Server();
 
-server.start();
+server.start()
+  .catch(err => {
+    console.log(err)
+    process.exit(-1)
+  })

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,8 @@ var express = require('express'),
   fs = require('fs'),
   FullSignalK = require('signalk-schema').FullSignalK,
   StreamBundle = require('./streambundle'),
-  SubscriptionManager = require('./subscriptionmanager')
+  SubscriptionManager = require('./subscriptionmanager'),
+  Mode = require('stat-mode')
 
 function Server(opts) {
   this.params = opts || {};
@@ -65,6 +66,10 @@ Server.prototype.start = function() {
 
   return new Promise((resolve, reject) => {
     createServer(app, function(err, server) {
+      if (err) {
+        reject(err)
+        return
+      }
       app.server = server;
       app.interfaces = {};
       app.connections = {};
@@ -96,8 +101,12 @@ Server.prototype.start = function() {
 function createServer(app, cb) {
   if(typeof app.config.settings.ssl === "undefined" || app.config.settings.ssl) {
     getCertificateOptions(function(err, options) {
-      debug("Starting server to serve both http and https")
-      cb(null, httpolyglot.createServer(options, app));
+      if(err) {
+        cb(err)
+      } else {
+        debug("Starting server to serve both http and https")
+        cb(null, httpolyglot.createServer(options, app));
+      }
     });
     return;
   };
@@ -112,17 +121,27 @@ function createServer(app, cb) {
   cb(null, server);
 }
 
+function hasStrictPermissions(stat) {
+  return new Mode(stat).toString() === '-r--------'
+}
+
 function getCertificateOptions(cb) {
-  try {
-    if(fs.statSync('./settings/ssl-key.pem').isFile() && fs.statSync('./settings/ssl-cert.pem')) {
-      debug("Using certificate ssl-key.pem and ssl-cert.pem in ./settings/");
-      cb(null, {
-        key: fs.readFileSync('./settings/ssl-key.pem'),
-        cert: fs.readFileSync('./settings/ssl-cert.pem')
-      });
-      return;
+  if(fs.existsSync('./settings/ssl-key.pem') && fs.existsSync('./settings/ssl-cert.pem')) {
+    if(!hasStrictPermissions(fs.statSync('./settings/ssl-key.pem'))) {
+      cb(new Error('./settings/ssl-key.pem must be accessible only by the user that is running the server, refusing to start'))
+      return
     }
-  } catch(e) {
+    if(!hasStrictPermissions(fs.statSync('./settings/ssl-cert.pem'))) {
+      cb(new Error('./settings/ssl-cert.pem must be accessible only by the user that is running the server, refusing to start'))
+      return
+    }
+    debug("Using certificate ssl-key.pem and ssl-cert.pem in ./settings/");
+    cb(null, {
+      key: fs.readFileSync('./settings/ssl-key.pem'),
+      cert: fs.readFileSync('./settings/ssl-cert.pem')
+    });
+    return;
+  } else {
     createCertificateOptions(cb);
   }
 }
@@ -137,8 +156,10 @@ function createCertificateOptions(cb) {
       console.error("Could not create SSL certificate:" + err.message)
       throw err
     } else {
-      fs.writeFile('./settings/ssl-key.pem', keys.serviceKey);
-      fs.writeFile('./settings/ssl-cert.pem', keys.certificate);
+      fs.writeFileSync('./settings/ssl-key.pem', keys.serviceKey);
+      fs.chmodSync('./settings/ssl-key.pem', '400');
+      fs.writeFileSync('./settings/ssl-cert.pem', keys.certificate);
+      fs.chmodSync('./settings/ssl-cert.pem', '400');
       cb(null, {
         key: keys.serviceKey,
         cert: keys.certificate

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "signalk-schema": "0.0.1-0",
     "signalk-to-nmea0183": "github:signalk/signalk-to-nmea0183",
     "signalk-zones": "signalk/signalk-zones",
+    "stat-mode": "^0.2.2",
     "stream-throttle": "^0.1.3",
     "through": ">=2.2.7 <3",
     "winston": "^1.0.0",


### PR DESCRIPTION
The server now refuses to start if permissions of ssl-key.pem or ssl-cert.pem include anything but owner's read permission (400).

Fixes #143.