### PR TITLE
Add environment override for streaming service and document environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ You can also configure the path to the settings file with environment variable `
 
 The http port can be configured separately with environment variable `PORT`. You can also [run on port 80 with systemd](https://github.com/tkurki/marinepi-provisioning/blob/d3d624629799a3b96234a90fc42bc22dae4fd3a2/roles/node-app/templates/node_app_systemd_socket.j2). Environment variable NMEA0183PORT sets the NMEA 0183 tcp port.
 
+Environment variables
+---------------------
+- `SIGNALK_NODE_SETTINGS` override the path to the settings file
+- `PORT` override the port for http/ws service
+- `NMEA0183PORT`  override the port for the NMEA 0183 over tcp service (default 10110)
+- `TCPSTREAMPORT` override the port for the Signal K Streaming (deltas) over TCP
+
 Real Inputs
 ---------------
 To hook the server up to your real inputs you need to create a configuration file that connects to your input source and applies the relevant parsers / converters in the provider pipeline.

--- a/lib/interfaces/tcp.js
+++ b/lib/interfaces/tcp.js
@@ -21,7 +21,7 @@ module.exports = function(app) {
   var openSockets = {};
   var idSequence = 0;
   var server = null;
-  var port = 5555;
+  var port = process.env.TCPSTREAMPORT || 5555;
   var api = {};
 
 


### PR DESCRIPTION
This PR adds TCPSTREAMPORT environment variable for overriding the default port for Signal K delta over TCP service and documents all the enviroment variables that the server honors.

