### PR TITLE
Add DISABLEPLUGINS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Environment variables
 - `PORT` override the port for http/ws service
 - `NMEA0183PORT`  override the port for the NMEA 0183 over tcp service (default 10110)
 - `TCPSTREAMPORT` override the port for the Signal K Streaming (deltas) over TCP
+- `DISABLEPLUGINS` disable all plugins so that they can not be enabled
 
 Real Inputs
 ---------------

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -35,8 +35,8 @@ module.exports = function(app) {
         res.json(app.plugins.map((plugin) => {
           var data = null
           try {
-            data = JSON.parse(fs.readFileSync(pathForPluginId(plugin.id), 'utf8'))
-          } catch (e) {
+            data = getPluginOptions(plugin.id)
+          } catch(e) {
             console.log(e.code + " " + e.path)
           }
           return {
@@ -62,6 +62,12 @@ function ensureExists(dir) {
 function pathForPluginId(id) {
   return path.join(__dirname, "../../plugin-config-data", id + '.json')
 }
+
+function savePluginOptions(pluginId, data, callback) {
+  const config = JSON.parse(JSON.stringify(data))
+  fs.writeFile(pathForPluginId(pluginId), JSON.stringify(data, null, 2), callback);
+}
+
 
 function getPluginOptions(id) {
   try
@@ -102,12 +108,13 @@ function registerPlugin(app, pluginName) {
   const restart = (newConfiguration) => {
     const pluginOptions = getPluginOptions(plugin.id)
     pluginOptions.configuration = newConfiguration
-    fs.writeFile(pathForPluginId(plugin.id), JSON.stringify(pluginOptions, null, 2), function(err) {
+    savePluginOptions(plugin.id, pluginOptions, (err) => {
       if(err) {
         console.error(err)
+      } else {
+        plugin.stop()
+        plugin.start(newConfiguration, restart)
       }
-      plugin.stop()
-      plugin.start(newConfiguration, restart)
     })
   }
   if (options && options.enabled) {
@@ -125,9 +132,10 @@ function registerPlugin(app, pluginName) {
       name: plugin.name
     })
   })
+
   router.post("/config", (req, res) => {
-    fs.writeFile(pathForPluginId(plugin.id), JSON.stringify(req.body, null, 2), function(err) {
-      if (err) {
+    savePluginOptions(plugin.id, req.body, (err) => {
+      if(err) {
         console.log(err)
         res.status(500)
         res.send(err)
@@ -135,11 +143,13 @@ function registerPlugin(app, pluginName) {
       }
       res.send("Saved configuration for plugin " + plugin.id)
       plugin.stop()
-      if (req.body && req.body.enabled) {
-        plugin.start(req.body.configuration, restart)
+      const options = getPluginOptions(plugin.id)
+      if(options.enabled) {
+        plugin.start(options.configuration, restart)
       }
-    });
+    })
   })
+
   if(typeof plugin.registerWithRouter != 'undefined') {
     plugin.registerWithRouter(router)
   }

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -70,20 +70,24 @@ function savePluginOptions(pluginId, data, callback) {
 
 
 function getPluginOptions(id) {
-  try
-  {
+  try {
     const optionsAsString = fs.readFileSync(pathForPluginId(id), 'utf8');
     try {
-      return JSON.parse(optionsAsString)
-    } catch (e) {
+      const options = JSON.parse(optionsAsString)
+      if(process.env.DISABLEPLUGINS) {
+        debug("Plugins disabled by configuration")
+        options.enabled = false
+      }
+      debug(optionsAsString)
+      return options
+    } catch(e) {
       console.error("Could not parse JSON options:" + optionsAsString);
       return {}
     }
-  } catch (e) {
+  } catch(e) {
     debug("Could not find options for plugin " + id + ", returning empty options")
     return {}
   }
-  return JSON.parse()
 }
 
 function startPlugins(app) {

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -54,7 +54,7 @@ module.exports = function(app) {
 };
 
 function ensureExists(dir) {
-  if (!fs.existsSync(dir)) {
+  if(!fs.existsSync(dir)) {
     fs.mkdirSync(dir);
   }
 }
@@ -92,10 +92,10 @@ function startPlugins(app) {
     var metadata;
     try {
       metadata = require('../../node_modules/' + pluginName + '/package.json')
-    } catch (e) {
+    } catch(e) {
       console.log(e)
     }
-    if (metadata && metadata.keywords && metadata.keywords.includes('signalk-node-server-plugin')) {
+    if(metadata && metadata.keywords && metadata.keywords.includes('signalk-node-server-plugin')) {
       registerPlugin(app, pluginName)
     }
   })
@@ -117,7 +117,7 @@ function registerPlugin(app, pluginName) {
       }
     })
   }
-  if (options && options.enabled) {
+  if(options && options.enabled) {
     debug('Starting plugin ' + pluginName)
     plugin.start(getPluginOptions(plugin.id).configuration, restart)
   }


### PR DESCRIPTION
This PR adds DISABLEPLUGINS environment variable, which overrides all plugins' `enabled` field to false when retrieving their configuration. Options are persisted as requested via http, but the plugins are never enabled.