### PR TITLE
Fix: set context (vessel) prune interval to 1 hour

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ Server.prototype.start = function() {
   var self = this;
   var app = this.app;
 
-  this.app.pruneInterval = setInterval(app.signalk.pruneContexts.bind(app.signalk, 7 * 60 * 1000), 60 * 1000);
+  this.app.pruneInterval = setInterval(app.signalk.pruneContexts.bind(app.signalk, 60 * 60), 60 * 1000);
   this.app.providers = [];
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
For some reason it was ~117 hours, with pruneContexts expecting seconds and getting
7 * 60 * 1000, which clearly is a mistake.