### PR TITLE
Fix nmea0183 conversion output over tcp

### DIFF
--- a/lib/interfaces/nmea-tcp.js
+++ b/lib/interfaces/nmea-tcp.js
@@ -43,7 +43,7 @@ module.exports = function(app) {
         delete openSockets[socket.id];
       })
     });
-    app.signalk.on('nmea0183', function(data) {
+    const send = (data) => {
       _.values(openSockets).forEach(function(socket) {
         try {
           socket.write(data + '\n');
@@ -51,7 +51,9 @@ module.exports = function(app) {
           console.error(e + ' ' + socket);
         }
       });
-    });
+    }
+    app.signalk.on('nmea0183', send);
+    app.on('nmea0183out', send);
     server.listen(port);
     debug("NMEA0138 tcp server listening on " + port);
   };


### PR DESCRIPTION
Signalk-to-nmea0183 plugin output was not being sent over tcp, because nmea-tcp was only listening to nmea0183 events, not nmea0183out events produced by the plugin.