### PR TITLE
Fix multiplexed log file playback

### DIFF
--- a/providers/multiplexedlog.js
+++ b/providers/multiplexedlog.js
@@ -73,21 +73,22 @@ function Splitter(options) {
 require('util').inherits(Splitter, Transform);
 
 Splitter.prototype._transform = function(msg, encoding, done) {
-  switch(msg.discriminator) {
-    case 'A':
-      return this.fromActisenseSerial.write(msg.data, encoding, done)
-      break
-    case 'N':
-      return this.fromNMEA0183.write(msg.data, encoding, done)
-      break
-    case 'I':
-      this.push(JSON.parse(msg.data))
-      done()
-      break
-    default:
-      console.log("Unrecognized discriminator")
-      done()
-
+  try {
+    switch(msg.discriminator) {
+      case 'A':
+        return this.fromActisenseSerial.write(msg.data, encoding)
+        break
+      case 'N':
+        return this.fromNMEA0183.write(msg.data, encoding)
+        break
+      case 'I':
+        this.push(JSON.parse(msg.data))
+        break
+      default:
+        console.log("Unrecognized discriminator")
+    }
+  } finally {
+    done()
   }
 }
 Splitter.prototype.pipe = function(target) {

--- a/providers/multiplexedlog.js
+++ b/providers/multiplexedlog.js
@@ -42,7 +42,7 @@ function DeMultiplexer(options) {
 
   this.toTimestamped = new ToTimestamped()
   this.timestampThrottle = new TimestampThrottle({
-    getMilliseconds: ts => ts
+    getMilliseconds: msg => msg.timestamp
   })
   this.splitter = new Splitter(options);
   if(options.noThrottle) {

--- a/providers/timestamp-throttle.js
+++ b/providers/timestamp-throttle.js
@@ -34,7 +34,7 @@ function TimestampThrottle(options) {
 require('util').inherits(TimestampThrottle, Transform);
 
 TimestampThrottle.prototype._transform = function(msg, encoding, done) {
-    var msgMillis = getMilliseconds(msg.timestamp);
+    var msgMillis = this.getMilliseconds(msg);
     if (msgMillis < this.lastMsgMillis) {
       this.offsetMillis = new Date().getTime() - msgMillis;
     }
@@ -52,9 +52,9 @@ TimestampThrottle.prototype._transform = function(msg, encoding, done) {
     }
 };
 
-function getMilliseconds(timestamp) {
+function getMilliseconds(msg) {
   //2014-08-15-16:00:00.083
-  return moment(timestamp, "YYYY-MM-DD-HH:mm:ss.SSS").valueOf()
+  return moment(msg.timestamp, "YYYY-MM-DD-HH:mm:ss.SSS").valueOf()
 }
 
 


### PR DESCRIPTION
Playback was utterly broken, in no less than three independent ways:
1. timestamp extraction was not calling the correct parameterised function so timestamp throttling was not working
2. done() was not being called, causing the pipeline to halt (masked by 1.)
3. multiplexedlog was not working as the end of a provider pipeline, because it did not emit 'data', just piped data to the next pipeline element, which is nonexistent if it is the end element

