### PR TITLE
feature: add check for minimum Node version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,6 +14,11 @@
  * limitations under the License.
 */
 
+if (typeof [].includes != 'function') {
+  console.log("Minimum required Node.js version is 6, please update.")
+  process.exit(-1)
+}
+
 var express = require('express'),
   _ = require('lodash'),
   debug = require('debug')('signalk-server'),


### PR DESCRIPTION
People frequently get a cryptic error message when starting with ancient Node. Instead show nice error message and bail out.