### PR TITLE
fix: always consume pipeElement output with .pipe(devnull)

### DIFF
--- a/lib/pipedproviders.js
+++ b/lib/pipedproviders.js
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-var deep = require('deep-get-set');
+const deep = require('deep-get-set')
+const devnull = new (require('dev-null-stream'))
 
 module.exports = function(app) {
   function createPipedProvider(providerConfig, nmea0183Listener) {
@@ -38,6 +39,7 @@ module.exports = function(app) {
       result.pipeElements[i].pipe(result.pipeElements[i + 1]);
     }
 
+    result.pipeElements[result.pipeElements.length - 1].pipe(devnull)
     result.pipeElements[result.pipeElements.length - 1].on('data', function(data) {
       if (data.updates) {
         if (typeof data.context === 'undefined') {
@@ -59,7 +61,7 @@ module.exports = function(app) {
   function createPipeElement(elementConfig) {
     var options = elementConfig.options || {};
     options.app = app;
-    
+
     if (elementConfig.optionMappings) {
       elementConfig.optionMappings.forEach(function(mapping) {
         if (deep(app, mapping.fromAppProperty)) {
@@ -85,7 +87,7 @@ module.exports = function(app) {
         }
         return result
       }, [])
-      
+
       return piped.filter(function(n){return n != null});
     } else {
       console.error("No pipedProviders in the settings file");

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cors": "^2.5.2",
     "debug": "^2.1.0",
     "deep-get-set": "^1.1.0",
+    "dev-null-stream": "0.0.1",
     "ejson": "^2.1.2",
     "errorhandler": "^1.3.0",
     "express": "^4.10.4",


### PR DESCRIPTION
Fixes #171. Multiplexedlog is getting stuck after 16 pushed json deltas, because
the internal buffer fills up. I have no idea why this happens with just this
provider and not others.
The deltas are actually handled with .on('data',...), so we can safely pipe
the ouput to devnull. However this is confusing - it would be better to
create a Writable  end element to the pipe and handle deltas finally
there. This way we could remove the explicit  calls
in Multiplexedlog.