### PR TITLE
fix: use host & port from request in /signalk

### DIFF
--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -55,9 +55,8 @@ module.exports = function(app) {
       });
 
       app.get(pathPrefix, function(req, res) {
-        var host = app.config.getExternalHostname();
-        var port = app.config.getExternalPort();
-        port = (port === '' || port === 80) ? '' : ':' + port;
+        var host = req.headers.host
+        var splitHost = host.split(':')
 
         var httpProtocol = 'http://';
         var wsProtocol = 'ws://';
@@ -70,9 +69,9 @@ module.exports = function(app) {
           'endpoints': {
             'v1': {
               'version': '1.alpha1',
-              'signalk-http': httpProtocol + host + port + apiPathPrefix,
-              'signalk-ws': wsProtocol + host + port + streamPath,
-              'signalk-tcp': 'tcp://' + host + ':3858'
+              'signalk-http': httpProtocol + host  + apiPathPrefix,
+              'signalk-ws': wsProtocol + host + streamPath,
+              'signalk-tcp': 'tcp://' + splitHost[0] + ':3858'
             }
           }
         });


### PR DESCRIPTION
With different proxying and hostname setups you need to either
separately configure what the server should use as host and port.
Or you can use the exact same host & port used in the request that
we are responding to. The same host is used for tcp as well.

Fixes #112.