### PR TITLE
feature: support timestamped 0183 playback with Multiplexedlog

### DIFF
--- a/providers/multiplexedlog.js
+++ b/providers/multiplexedlog.js
@@ -82,17 +82,21 @@ Splitter.prototype._transform = function(msg, encoding, done) {
     switch(msg.discriminator) {
       case 'A':
         return this.fromActisenseSerial.write(msg.data, encoding)
-        break
-      case 'N':
-        return this.fromNMEA0183.write(msg.data, encoding)
-        break
-      case 'I':
-        const parsed = JSON.parse(msg.data)
-        this.push(parsed)
-        this.demuxEmitData(parsed)
+      case "C":
+      case "N":
+      case "G":
+        return this.fromNMEA0183.write({line:msg.data, timestamp: msg.timestamp}, encoding)
+      case "I":
+        try {
+          const parsed = JSON.parse(msg.data)
+          this.push(parsed)
+          this.demuxEmitData(parsed)
+        } catch (e) {
+          console.error(e)
+        }
         break
       default:
-        console.log("Unrecognized discriminator")
+        console.log("Unrecognized discriminator:" + msg.discriminator)
     }
   } finally {
     done()

--- a/providers/nmea0183-signalk.js
+++ b/providers/nmea0183-signalk.js
@@ -27,7 +27,12 @@ function ToSignalK(options) {
   this.parser.on('nmea0183', function(sentence) {
     that.emit('nmea0183', sentence)
   });
-  this.parser.on('delta', function(delta) {
+  this.parser.on('delta', function (delta) {
+    if (that.timestamp) {
+      delta.updates.forEach(update => {
+        update.timestamp = that.timestamp
+      })
+    }
     that.push(delta);
   });
 }
@@ -36,7 +41,12 @@ require('util').inherits(ToSignalK, Transform);
 
 ToSignalK.prototype._transform = function(chunk, encoding, done) {
   try {
-    this.parser.write(chunk + '\n');
+    if (typeof chunk === 'object') {
+      this.timestamp = new Date(Number(chunk.timestamp))
+      this.parser.write(chunk.line + '\n')
+    } else {
+      this.parser.write(chunk + '\n');
+    }
   } catch (ex) {
     console.error(ex);
   }


### PR DESCRIPTION
Previously 0183 playback was output with current time timestamps in
deltas. This commit adds the timestamps to the deltas that 0183 parser
emits. This assumes that 0183 parsing is synchronous so that
the timestamp stored when calling parser.write will be the correct one
when 0183 parser emits deltas.