### PR TITLE
fix: handle vessels.self context properly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -78,7 +78,7 @@ function Server(opts) {
 
   app.handleMessage = function(providerId, data) {
     if(data && data.updates) {
-      if(typeof data.context === 'undefined') {
+      if(typeof data.context === 'undefined' || data.context === 'vessels.self') {
         data.context = 'vessels.' + app.selfId;
       }
       data.updates.forEach(function(update) {


### PR DESCRIPTION
Previously a delta with context 'vessels.self' created a vessel with id
self, which confusingly had nothing to do with response to http requests
with /vessels/self path, which fetch data from under the vessel
identified with the self id from the configuration.

This fixes the situation so that deltas with 'vessels.self' context are
routed to under the vessel with the self id.