### PR TITLE
fix: tcp port in /signalk and mdns

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -239,7 +239,7 @@ function startInterfaces(app) {
       if(app.interfaces[name] && _.isFunction(app.interfaces[name].start)) {
         if(_.isUndefined(app.interfaces[name].forceInactive) || !app.interfaces[name].forceInactive) {
           debug("Starting interface '" + name + "'");
-          app.interfaces[name].start();
+          app.interfaces[name].data = app.interfaces[name].start();
         } else {
           debug("Not starting interface '" + name + "' by forceInactive")
         }

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -65,14 +65,19 @@ module.exports = function(app) {
           wsProtocol = 'wss://';
         }
 
+        const services = {
+          'version': '1.alpha1',
+          'signalk-http': httpProtocol + host  + apiPathPrefix,
+          'signalk-ws': wsProtocol + host + streamPath
+        }
+
+        if (app.interfaces.tcp && app.interfaces.tcp.data) {
+          services['signalk-tcp'] = 'tcp://' + splitHost[0] + app.interfaces.tcp.data.port
+        }
+
         res.json({
           'endpoints': {
-            'v1': {
-              'version': '1.alpha1',
-              'signalk-http': httpProtocol + host  + apiPathPrefix,
-              'signalk-ws': wsProtocol + host + streamPath,
-              'signalk-tcp': 'tcp://' + splitHost[0] + ':3858'
-            }
+            'v1': services
           }
         });
       })

--- a/lib/interfaces/tcp.js
+++ b/lib/interfaces/tcp.js
@@ -23,7 +23,7 @@ module.exports = function(app) {
   var openSockets = {};
   var idSequence = 0;
   var server = null;
-  var port = process.env.TCPSTREAMPORT || 5555;
+  var port = process.env.TCPSTREAMPORT || 3858;
   var api = {};
 
 
@@ -77,6 +77,9 @@ module.exports = function(app) {
       server.listen(port)
     }
     debug("Tcp delta server listening on " + port);
+    return {
+      port: port
+    }
   };
 
   api.stop = function() {
@@ -89,7 +92,7 @@ module.exports = function(app) {
   api.mdns = {
     name: "_signalk-tcp",
     type: "tcp",
-    port: 3858
+    port: port
   };
 
   function getHello() {

--- a/lib/mdns.js
+++ b/lib/mdns.js
@@ -89,8 +89,8 @@ module.exports = function mdnsResponder(app) {
   let ads = [];
   for (var i in types) {
     let type = types[i];
-    debug("Starting mDNS ad: " + type.type + " " + app.config.getExternalHostname() + ":" + app.config.getExternalPort());
-    let ad = new mdns.Advertisement(type.type, Number(app.config.getExternalPort()), options);
+    debug("Starting mDNS ad: " + type.type + " " + app.config.getExternalHostname() + ":" + type.port);
+    let ad = new mdns.Advertisement(type.type, type.port, options);
     ad.start();
     ads.push(ad);
   }


### PR DESCRIPTION
Fix the default port for deltas over tcp to be 3858. Replace the hard coded
value in /signalk response with the one actually used and omit the tcp
service if it is not active. Fix mdns to use the actual port in use
in the service instead of the http/ws port.

Fixes #191 