### PR TITLE
Point to log file (multiplexed)

### DIFF
--- a/settings/multiplexed.json
+++ b/settings/multiplexed.json
@@ -7,6 +7,7 @@
     "pipeElements": [{
       "type": "providers/filestream",
       "options": {
+        "filename": "",
         "keepRunning": true
       },
       "optionMappings": [{


### PR DESCRIPTION
The multiplexed log example does not point to a log file for playback