### PR TITLE
feature: add support for organisation npm modules

### DIFF
--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -18,6 +18,8 @@ var debug = require('debug')('signalk:interfaces:plugins')
 var fs = require('fs')
 var path = require('path')
 var express = require('express')
+const modulesWithKeyword = require("../modules");
+
 
 module.exports = function(app) {
 
@@ -93,16 +95,8 @@ function getPluginOptions(id) {
 
 function startPlugins(app) {
   app.plugins = []
-  fs.readdirSync('./node_modules/').filter(name => name != '.bin').forEach(pluginName => {
-    var metadata;
-    try {
-      metadata = require('../../node_modules/' + pluginName + '/package.json')
-    } catch(e) {
-      console.log(e)
-    }
-    if(metadata && metadata.keywords && metadata.keywords.includes('signalk-node-server-plugin')) {
-      registerPlugin(app, pluginName, metadata)
-    }
+  modulesWithKeyword('signalk-node-server-plugin').forEach(moduleData => {
+    registerPlugin(app, moduleData.module, moduleData.metadata)
   })
 }
 

--- a/lib/interfaces/webapps.js
+++ b/lib/interfaces/webapps.js
@@ -14,34 +14,30 @@
  * limitations under the License.
 */
 
-var debug = require('debug')('signalk:interfaces:webapps')
-var fs = require('fs')
-var path = require('path')
-var express = require('express')
+var debug = require("debug")("signalk:interfaces:webapps");
+var fs = require("fs");
+var path = require("path");
+var express = require("express");
+const modulesWithKeyword = require("../modules");
 
 module.exports = function(app) {
   return {
     start: function() {
-      mountWebapps(app)
+      mountWebapps(app);
     },
     stop: function() {}
-  }
+  };
 };
 
 function mountWebapps(app) {
-  debug("MountWebApps")
-  fs.readdirSync('./node_modules/').filter(name => name != '.bin').forEach(pluginName => {
-    var metadata;
-    try {
-      metadata = require('../../node_modules/' + pluginName + '/package.json')
-    } catch(e) {
-      console.log(e)
-    }
-    if(metadata && metadata.keywords && metadata.keywords.includes('signalk-webapp')) {
-      const webappPath = path.join(__dirname, '../../node_modules/' + pluginName)
-      debug("Mounting webapp /" + pluginName + ":" + webappPath)
-      app.use('/' + pluginName, express.static(webappPath));
-      app.webapps.push(metadata)
-    }
-  })
+  debug("MountWebApps");
+  modulesWithKeyword("signalk-webapp").forEach(moduleData => {
+    const webappPath = path.join(
+      __dirname,
+      "../../node_modules/" + moduleData.module
+    );
+    debug("Mounting webapp /" + moduleData.module + ":" + webappPath);
+    app.use("/" + moduleData.module, express.static(webappPath));
+    app.webapps.push(moduleData.metadata);
+  });
 }

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Teppo Kurki <teppo.kurki@iki.fi>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+const fs = require("fs");
+
+function modulesWithKeyword(keyword) {
+  return findModulesInDir("./node_modules/", keyword);
+}
+
+function findModulesInDir(dir, keyword) {
+  return fs
+    .readdirSync(dir)
+    .filter(name => name != ".bin")
+    .reduce((result, filename) => {
+      if (filename.indexOf("@") === 0) {
+        return result.concat(
+          findModulesInDir(dir + filename + "/", keyword).map(entry => {
+            return {
+              module: filename + "/" + entry.module,
+              metadata: entry.metadata
+            };
+          })
+        );
+      } else {
+        let metadata;
+        try {
+          metadata = require("../" + dir + filename + "/package.json");
+        } catch (err) {
+          console.log(err);
+        }
+        if (
+          metadata &&
+          metadata.keywords &&
+          metadata.keywords.includes(keyword)
+        ) {
+          result.push({ module: filename, metadata: metadata });
+        }
+      }
+      return result;
+    }, []);
+}
+
+module.exports = modulesWithKeyword;


### PR DESCRIPTION
Npm has organisations, whose modules are under node_modules/orgname.
This adds support for the subdirectories when fetching modules
by keyword in webapps and plugins.