### PR TITLE
feature: add plugin signalKApiRoutes hook

### DIFF
--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -162,4 +162,8 @@ function registerPlugin(app, pluginName, metadata) {
     plugin.registerWithRouter(router)
   }
   app.use("/plugins/" + plugin.id, router)
+
+  if(typeof plugin.signalKApiRoutes === 'function') {
+    app.use("/signalk/v1/api", plugin.signalKApiRoutes(express.Router()))
+  }
 }

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -29,7 +29,7 @@ module.exports = function(app) {
     start: function() {
       app.use('/', express.static(__dirname + '/../../public'));
 
-      app.get(apiPathPrefix + '*', function(req, res) {
+      app.get(apiPathPrefix + '*', function(req, res, next) {
         var path = String(req.path).replace(apiPathPrefix, '');
         var data = app.signalk.retrieve();
         var last = data;
@@ -46,7 +46,7 @@ module.exports = function(app) {
           if(typeof last[p] !== 'undefined') {
             last = last[p];
           } else {
-            res.status(404).send("Not found");
+            next()
             return
           }
         }


### PR DESCRIPTION
Add support for `signalKApiRoutes(router)` hook: a plugin can
easily register /signalk/vX/api/ routes without knowledge of the exact
path where SK api is mounted.