### PR TITLE
Use mmsi of both mmsi and uuid are present

### DIFF
--- a/lib/config/cli.js
+++ b/lib/config/cli.js
@@ -6,7 +6,6 @@
  * You may obtain a copy of the License at
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
-
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -59,12 +58,12 @@ module.exports = function(app) {
   }
 
   if(typeof app.config.settings.vessel === 'object' && app.config.settings.vessel !== null && (typeof app.config.settings.vessel.uuid === 'string' || typeof app.config.settings.vessel.mmsi === 'string')) {
-    app.selfType = 'uuid';
-    app.selfId = app.config.settings.vessel.uuid;
+    app.selfType = 'mmsi';
+    app.selfId = app.config.settings.vessel.mmsi;
 
-    if(typeof app.selfId === "undefined" && app.config.settings.vessel.mmsi) {
-      app.selfType = 'mmsi';
-      app.selfId = app.config.settings.vessel.mmsi;
+    if(typeof app.selfId === "undefined" && app.config.settings.vessel.uuid) {
+      app.selfType = 'uuid';
+      app.selfId = app.config.settings.vessel.uuid;
     }
 
     debug(app.selfType.toUpperCase() + ": " + app.selfId);


### PR DESCRIPTION
This is a switch in logic. If both mmsi and uuid are present, mmsi should be selected, as this is an unique number with an international register. #209 