### PR TITLE
fix: better mapcache error handling

### DIFF
--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -22,7 +22,8 @@ const pathPrefix = "/signalk";
 const versionPrefix = "/v1";
 const apiPathPrefix = pathPrefix + versionPrefix + "/api/";
 const parseStringAsync = Promise.promisify(require("xml2js").parseString);
-const chartBaseDir = __dirname + "/../../public/mapcache/";
+const path = require("path");
+const chartBaseDir = path.join(__dirname, "..", "..", "public", "mapcache");
 
 const chartProviders = {};
 loadCharts();
@@ -85,31 +86,38 @@ module.exports = function(app) {
 };
 
 function loadCharts(app, req) {
-  return fs.readdirAsync(chartBaseDir).then(files => {
-    return Promise.props(
-      files.reduce((result, file) => {
-        result[file] = fs
-          .statAsync(chartBaseDir + file)
-          .then(stat => {
-            if (stat.isDirectory()) {
-              return directoryToMapInfo(file);
-            } else {
-              return fileToMapInfo(file);
-            }
-          })
-          .catch(err => {
-            console.error(err + " " + file);
-            return undefined;
-          });
-        return result;
-      }, {})
-    );
-  });
+  return fs
+    .readdirAsync(chartBaseDir)
+    .then(files => {
+      return Promise.props(
+        files.reduce((result, file) => {
+          result[file] = fs
+            .statAsync(path.join(chartBaseDir, file))
+            .then(stat => {
+              if (stat.isDirectory()) {
+                return directoryToMapInfo(file);
+              } else {
+                return fileToMapInfo(file);
+              }
+            })
+            .catch(err => {
+              console.error(err + " " + file);
+              return undefined;
+            });
+          return result;
+        }, {})
+      );
+    })
+    .catch(err => {
+      console.error("Error reading " + chartBaseDir);
+      return {};
+    });
 }
 
 function directoryToMapInfo(dir) {
+  const resourceFile = path.join(chartBaseDir, dir, tilemapresource.xml);
   return fs
-    .readFileAsync(chartBaseDir + dir + "/tilemapresource.xml")
+    .readFileAsync(resourceFile)
     .then(resXml => {
       return parseStringAsync(resXml);
     })
@@ -128,6 +136,10 @@ function directoryToMapInfo(dir) {
         tilemapUrl: "/mapcache/" + dir,
         scale: parseInt(scale)
       };
+    })
+    .catch(err => {
+      console.error("Error reading " + resourceFile + " " + err.message);
+      return {};
     });
 }
 


### PR DESCRIPTION
Add public/mapcache to git to make sure it exists. Use path.join to
construct the paths. Add catch blocks to handle error conditions
instead of having the errors just bubble out.

Fixes #212