### PR TITLE
feature: allow multiple events in 0183 out and serial in

### DIFF
--- a/providers/nmea0183-signalk.js
+++ b/providers/nmea0183-signalk.js
@@ -14,12 +14,19 @@
  * limitations under the License.
  */
 
- /* Usage: this is the pipeElement that transforms NMEA0183 input to Signal K deltas
- * It does not take any options, as selfId and selfType are fetched from app properties
+/* Usage: this is the pipeElement that transforms NMEA0183 input to Signal K deltas
+ * SelfId and selfType are fetched from app properties. Emits sentence data as "nmea0183"
+ * events on app.signalk by default. Furthermore you can use "sentenceEvent" option,
+ * that will cause sentence data to be emitted as events on app. sentenceEvent can
+ * be a string or an array of strings.
+ *
  * Example:
 
  {
    "type": "providers/nmea0183-signalk",
+   "options": {
+     "sentenceEvent": "nmea0183-1"
+   },
    "optionMappings": [
      {
        "fromAppProperty": "selfId",
@@ -34,44 +41,54 @@
 
  */
 
-var Transform = require('stream').Transform;
+const Transform = require("stream").Transform;
+const isArray = require("lodash").isArray;
+
 
 function ToSignalK(options) {
   Transform.call(this, {
     objectMode: true
   });
 
-  this.parser = new(require('nmea0183-signalk').Parser)(options);
+  this.parser = new (require("nmea0183-signalk")).Parser(options);
 
   var that = this;
-  this.parser.on('nmea0183', function(sentence) {
-    that.emit('nmea0183', sentence)
+  this.parser.on("nmea0183", function(sentence) {
+    that.emit("nmea0183", sentence);
   });
-  this.parser.on('delta', function (delta) {
+
+  if (options.sentenceEvent) {
+    (isArray(options.sentenceEvent)
+      ? options.sentenceEvent
+      : [options.sentenceEvent]).forEach(event => {
+      that.parser.on("nmea0183", sentence => options.app.emit(event, sentence));
+    });
+  }
+
+  this.parser.on("delta", function(delta) {
     if (that.timestamp) {
       delta.updates.forEach(update => {
-        update.timestamp = that.timestamp
-      })
+        update.timestamp = that.timestamp;
+      });
     }
     that.push(delta);
   });
 }
 
-require('util').inherits(ToSignalK, Transform);
+require("util").inherits(ToSignalK, Transform);
 
 ToSignalK.prototype._transform = function(chunk, encoding, done) {
   try {
-    if (typeof chunk === 'object' && typeof chunk.line === 'string') {
-      this.timestamp = new Date(Number(chunk.timestamp))
-      this.parser.write(chunk.line + '\n')
+    if (typeof chunk === "object" && typeof chunk.line === "string") {
+      this.timestamp = new Date(Number(chunk.timestamp));
+      this.parser.write(chunk.line + "\n");
     } else {
-      this.parser.write(chunk + '\n');
+      this.parser.write(chunk + "\n");
     }
   } catch (ex) {
     console.error(ex);
   }
   done();
-}
-
+};
 
 module.exports = ToSignalK;

--- a/providers/serialport.js
+++ b/providers/serialport.js
@@ -14,16 +14,22 @@
  * limitations under the License.
  */
 
- /* Usage: This is the first pipeElement in a PipedProvider. Used to pass data input from Serial to the next pipeElement. 
+/* Usage: This is the first pipeElement in a PipedProvider. Used to pass data input from Serial
+ * to the next pipeElement.
  * Reads data from a serial device and allows writing back to serial with the "toStdout" option 
- * It takes two options; "device" and "baudrate". The "toStdout" option is not mandatory.
+ * It takes two options; "device" and "baudrate".
+ *
+ * The "toStdout" option is not mandatory. It routes events emitted on app with that name to
+ * serial output, followed by newline. toStdout can be a string or an array of strings.
+ *
  * Example:
 
  {
    "type": "providers/serialport",
    "options": {
      "device": "/dev/ttyUSB0",
-     "baudrate": 4800
+     "baudrate": 4800,
+     "toStdout": "nmea0183out1"
    },
    "optionMappings": [
      {
@@ -40,11 +46,12 @@
 
  */
 
-var Transform = require('stream').Transform
-var SerialPort = require('serialport');
+const Transform = require("stream").Transform;
+const SerialPort = require("serialport");
+const isArray = require("lodash").isArray;
 
 function SerialStream(options) {
-  if(!(this instanceof SerialStream)) {
+  if (!(this instanceof SerialStream)) {
     return new SerialStream(options);
   }
 
@@ -56,16 +63,16 @@ function SerialStream(options) {
   this.start();
 }
 
-require('util').inherits(SerialStream, Transform);
+require("util").inherits(SerialStream, Transform);
 
 SerialStream.prototype.start = function() {
-  if(this.serial !== null) {
+  if (this.serial !== null) {
     this.serial.unpipe(this);
     this.serial.removeAllListeners();
     this.serial = null;
   }
 
-  if(this.reconnect === false) {
+  if (this.reconnect === false) {
     return;
   }
 
@@ -74,19 +81,25 @@ SerialStream.prototype.start = function() {
     parser: SerialPort.parsers.readline("\n")
   });
 
-  this.serial.on('open', function() {
-    this.serial.pipe(this);
-  }.bind(this));
+  this.serial.on(
+    "open",
+    function() {
+      this.serial.pipe(this);
+    }.bind(this)
+  );
 
-  this.serial.on('error', function(x) {console.log(x)});
-  this.serial.on('close', this.start.bind(this));
+  this.serial.on("error", function(x) {
+    console.log(x);
+  });
+  this.serial.on("close", this.start.bind(this));
 
   var that = this;
-  const stdOutEvent = this.options.toStdout
-  if(stdOutEvent) {
-    this.options.app.on(stdOutEvent, function(d) {
-      that.serial.write(d + '\n');
-    })
+  const stdOutEvent = this.options.toStdout;
+  if (stdOutEvent) {
+    (isArray(stdOutEvent) ? stdOutEvent : [stdOutEvent]).forEach(event => {
+      console.log(event)
+      that.options.app.on(event, d => that.serial.write(d + "\n"));
+    });
   }
 };
 

--- a/settings/volare-serial-settings.json
+++ b/settings/volare-serial-settings.json
@@ -23,7 +23,8 @@
          "type": "providers/serialport",
          "options": {
            "device": "/dev/ttyUSB0",
-           "baudrate": 4800
+           "baudrate": 4800,
+           "toStdout": ["nmea0183out1", "nmea0183out2"]
          },
          "optionMappings": [
            {
@@ -39,6 +40,9 @@
        },
        {
           "type": "providers/nmea0183-signalk",
+          "options":{
+            "sentenceEvent": "nmea0183in1"
+          },
           "optionMappings": [
             {
              "fromAppProperty": "selfId",


### PR DESCRIPTION
This adds the ability to specify that nmea0183-signalk provider emits sentences as one
or more events. Furthermore it allows serial provider to listen for multiple events for
data to be written to serial out.