### PR TITLE
Fixed period AIS subscription loses updates

### DIFF
--- a/lib/subscriptionmanager.js
+++ b/lib/subscriptionmanager.js
@@ -56,24 +56,30 @@ function handleSubscribeRow(subscribeRow, unsubscribes, buses, filter, callback,
       var filteredBus = bus.filter(filter)
       if (subscribeRow.minPeriod) {
         if (subscribeRow.policy && subscribeRow.policy != 'instant') {
-          errorCallback("minPeriod assumes policy 'instant', ignoring " + subscribeRow.policy)
+          errorCallback("minPeriod assumes policy 'instant', ignoring policy " + subscribeRow.policy)
         }
         debug("minPeriod:" + subscribeRow.minPeriod)
         filteredBus = filteredBus.debounceImmediate(subscribeRow.minPeriod)
       } else if (subscribeRow.period || (subscribeRow.policy && subscribeRow.policy === 'fixed')) {
         if (subscribeRow.policy && subscribeRow.policy != 'fixed') {
-          errorCallback("period assumes policy 'fixed', ignoring " + subscribeRow.policy)
+          errorCallback("period assumes policy 'fixed', ignoring policy " + subscribeRow.policy)
         } else {
           const interval = subscribeRow.period || 1000
-          //this may leak setIntervals underneath the hood
-          filteredBus = filteredBus.sampledBy(Bacon.interval(interval, true))
+          filteredBus = filteredBus.bufferWithTime(interval)
+            .flatMapLatest(bufferedValues => {
+              const uniqueValues = _(bufferedValues)
+                .reverse()
+                .uniqBy(value => value.context + ":" + value.$source + ":" + value.path)
+                .value()
+              return Bacon.fromArray(uniqueValues)
+            })
         }
       }
       if (subscribeRow.format && subscribeRow.format != 'delta') {
         errorCallback("Only delta format supported, using it")
       }
       if (subscribeRow.policy && !['instant', 'fixed'].some(s => s === subscribeRow.policy)) {
-        errorCallback("Only 'instant' and 'fixed' policies supported, ignoring " + subscribeRow.policy)
+        errorCallback("Only 'instant' and 'fixed' policies supported, ignoring policy " + subscribeRow.policy)
       }
       unsubscribes.push(filteredBus.map(toDelta).onValue(callback))
     }


### PR DESCRIPTION
Fix for issue: https://github.com/SignalK/signalk-server-node/issues/220

Fixes subscription protocol when subscribing to AIS targets with fixed period:
```
{
  context: 'vessels.*',
  subscribe: [
    {path: '*', period: 10000}
  ]
}
```

Previous implementation lost vessel data while sampling the incoming events. This fix will buffer all incoming `filteredBus` events and ensure that one value for each vessel+source+path will be emitted after the given `period`.

Remaining issues:
- Several `delta` events will be emitted simultaneously on every `period`, each containing only one `updates` value.  Optimal solution would emit only one `delta` event containing everything, but this would require some changes to the internal subscription architecture.
- `minPeriod` is left untouched and will still lose some AIS vessel data.

