### PR TITLE
fix: output \r\n lineseparator in serialport

### DIFF
--- a/providers/serialport.js
+++ b/providers/serialport.js
@@ -98,7 +98,7 @@ SerialStream.prototype.start = function() {
   if (stdOutEvent) {
     (isArray(stdOutEvent) ? stdOutEvent : [stdOutEvent]).forEach(event => {
       console.log(event)
-      that.options.app.on(event, d => that.serial.write(d + "\n"));
+      that.options.app.on(event, d => that.serial.write(d + "\r\n"));
     });
   }
 };


### PR DESCRIPTION
Serialport, which is probably almost exclusively used for NMEA0183 output, should output the proper NMEA0183 line separator `\r\n`.