### PR TITLE
Fix mbtiles: ignore non mbtiles files and fix mbtiles path

### DIFF
--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -146,7 +146,7 @@ function directoryToMapInfo(dir) {
 
 function fileToMapInfo(file) {
   return new Promise((resolve, reject) => {
-    new MBTiles(chartBaseDir + file, (err, mbtiles) => {
+    new MBTiles(path.join(chartBaseDir, file), (err, mbtiles) => {
       if (err) {
         reject(err);
       }

--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -17,6 +17,7 @@ const debug = require("debug")("signalk-server:interfaces:charts");
 const Promise = require("bluebird");
 const fs = Promise.promisifyAll(require("fs"));
 const MBTiles = require("@mapbox/mbtiles");
+const _ = require('lodash');
 
 const pathPrefix = "/signalk";
 const versionPrefix = "/v1";
@@ -152,6 +153,9 @@ function fileToMapInfo(file) {
       mbtiles.getInfo((err, mbtilesData) => {
         if (err) {
           reject(err);
+        }
+        if (_.isUndefined(mbtilesData.name)) {
+          resolve(undefined);
         }
         chartProviders[file] = mbtiles;
         resolve({


### PR DESCRIPTION
Fixes #239 by treating only files that actually are in mbtiles format as chart providers.