### PR TITLE
fix: use providerId as $source

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,6 +84,10 @@ function Server(opts) {
       data.updates.forEach(function(update) {
         if(typeof update.source != "undefined") {
           update.source.label = providerId;
+        } else {
+          if (typeof update["$source"] === "undefined") {
+            update["$source"] = providerId;
+          }
         }
         if(!update.timestamp) {
           update.timestamp = (new Date()).toISOString();


### PR DESCRIPTION
If delta is missing both source and $source, use providerId as $source.