### PR TITLE
fix: app store can display more than 20 plugins or webapps

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -67,7 +67,7 @@ function installModule(name, version, onData, onErr, onClose) {
 function findModulesWithKeyword(keyword) {
   return agent(
     "GET",
-    "http://registry.npmjs.org/-/v1/search?text=keywords:" + keyword
+    "http://registry.npmjs.org/-/v1/search?size=250&text=keywords:" + keyword
   )
     .end()
     .then(response => {


### PR DESCRIPTION
npm search defaults to only 20 results