### PR TITLE
Ignore mapcache files that are not .mbtiles

### DIFF
--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -145,6 +145,11 @@ function directoryToMapInfo(dir) {
 }
 
 function fileToMapInfo(file) {
+
+  debug(file + 'file extension: ' + path.extname(file).substring(1));
+  if(path.extname(file).substring(1)!=='mbtiles'){
+    return; //don't process files that are not .mbtiles
+  }
   return new Promise((resolve, reject) => {
     new MBTiles(path.join(chartBaseDir, file), (err, mbtiles) => {
       if (err) {
@@ -155,7 +160,7 @@ function fileToMapInfo(file) {
           reject(err);
         }
         if (_.isUndefined(mbtilesData.name)) {
-          resolve(undefined);
+          reject(err);
         }
         chartProviders[file] = mbtiles;
         resolve({


### PR DESCRIPTION
Some OSes (like OSX) produce files in the folders that should not be processed. This also fixes the ```if (_.isUndefined(mbtilesData.name)) {
TypeError: Cannot read property 'name' of undefined```
 error and crash. 