### PR TITLE
Mbtiles error handling

### DIFF
--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -154,7 +154,7 @@ function fileToMapInfo(file) {
         if (err) {
           reject(err);
         }
-        if (_.isUndefined(mbtilesData.name)) {
+        if (_.isUndefined(mbtilesData) || _.isUndefined(mbtilesData.name)) {
           resolve(undefined);
         }
         chartProviders[file] = mbtiles;

--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -149,13 +149,16 @@ function fileToMapInfo(file) {
     new MBTiles(path.join(chartBaseDir, file), (err, mbtiles) => {
       if (err) {
         reject(err);
+        return;
       }
       mbtiles.getInfo((err, mbtilesData) => {
         if (err) {
           reject(err);
+          return;
         }
         if (_.isUndefined(mbtilesData) || _.isUndefined(mbtilesData.name)) {
           resolve(undefined);
+          return;
         }
         chartProviders[file] = mbtiles;
         resolve({

--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -17,7 +17,7 @@ const debug = require("debug")("signalk-server:interfaces:charts");
 const Promise = require("bluebird");
 const fs = Promise.promisifyAll(require("fs"));
 const MBTiles = require("@mapbox/mbtiles");
-const _ = require('lodash');
+const _ = require("lodash");
 
 const pathPrefix = "/signalk";
 const versionPrefix = "/v1";
@@ -116,7 +116,7 @@ function loadCharts(app, req) {
 }
 
 function directoryToMapInfo(dir) {
-  const resourceFile = path.join(chartBaseDir, dir, 'tilemapresource.xml');
+  const resourceFile = path.join(chartBaseDir, dir, "tilemapresource.xml");
   return fs
     .readFileAsync(resourceFile)
     .then(resXml => {

--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -140,7 +140,7 @@ function directoryToMapInfo(dir) {
     })
     .catch(err => {
       console.error("Error reading " + resourceFile + " " + err.message);
-      return {};
+      return undefined;
     });
 }
 


### PR DESCRIPTION
Handle erroneous or invalid mbtilesdata files properly. This replaces #251 and fixes #252, see also #253.