### PR TITLE
add colon (:) to tcp endpoint

### DIFF
--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -72,7 +72,7 @@ module.exports = function(app) {
         }
 
         if (app.interfaces.tcp && app.interfaces.tcp.data) {
-          services['signalk-tcp'] = 'tcp://' + splitHost[0] + app.interfaces.tcp.data.port
+          services['signalk-tcp'] = `tcp://${splitHost[0]}:${app.interfaces.tcp.data.port}`
         }
 
         res.json({


### PR DESCRIPTION
The TCP endpoint indicated on the API root (i.e. `http://localhost:3000/signalk`) was listed without the colon (i.e. `tcp://localhostXXXX` instead of `tcp://localhost:XXXX`).