### PR TITLE
refactor: rewrite logging provider without Winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "node-gpsd": "^0.3.0",
     "pem": "^1.8.1",
     "primus": "^7.0.0",
+    "rotating-file-stream": "^1.2.2",
     "sailgauge": "github:signalk/sailgauge",
     "serialport": "^4.0.3",
     "set-system-time": "github:tkurki/set-system-time",
@@ -95,8 +96,6 @@
     "stat-mode": "^0.2.2",
     "stream-throttle": "^0.1.3",
     "through": ">=2.2.7 <3",
-    "winston": "^2.3.0",
-    "winston-daily-rotate-file": "^1.4.4",
     "ws": "^3.0.0",
     "xml2js": "^0.4.17"
   },


### PR DESCRIPTION
Winston is needlessly complex and has a bit of overhead (for example
it clones each log message) for the rather simple task of writing
line by line timestamped logs. This replaces Winston with more
simple file writing using rotating-file-stream module.