### PR TITLE
Producer that allows users to filter out certain keys in a pipedProviders chain

### DIFF
--- a/bin/nmea-from-file-filtered
+++ b/bin/nmea-from-file-filtered
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+DIR=`dirname $0`
+${DIR}/signalk-server -s ${DIR}/../settings/volare-file-settings-filtered.json $*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5080 @@
+{
+  "name": "signalk-server",
+  "version": "0.1.28",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@mapbox/mbtiles": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mbtiles/-/mbtiles-0.9.0.tgz",
+      "integrity": "sha1-Ne4WT9lsi4stHZRfLEfoM96KFvE=",
+      "requires": {
+        "@mapbox/sphericalmercator": "1.0.5",
+        "@mapbox/tiletype": "0.3.1",
+        "d3-queue": "2.0.3",
+        "sqlite3": "3.1.9"
+      }
+    },
+    "@mapbox/sphericalmercator": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.0.5.tgz",
+      "integrity": "sha1-cCN7l3QJXtHP286nqP0fyCsmkfI="
+    },
+    "@mapbox/tiletype": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiletype/-/tiletype-0.3.1.tgz",
+      "integrity": "sha1-GhSY9qG3d2MOC006L+2dlJWVYMw="
+    },
+    "accepts": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "requires": {
+        "mime-types": "2.1.16",
+        "negotiator": "0.6.1"
+      }
+    },
+    "access-control": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/access-control/-/access-control-1.0.0.tgz",
+      "integrity": "sha1-rrooLO53MT6FJAFj1p41sp421iY=",
+      "requires": {
+        "millisecond": "0.1.2",
+        "setheader": "0.0.4",
+        "vary": "1.1.1"
+      }
+    },
+    "acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c="
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+    },
+    "ansi-styles": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
+      "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg="
+    },
+    "application-config": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/application-config/-/application-config-0.1.2.tgz",
+      "integrity": "sha1-MnJTO1+fg7MjqeXWQKNVi1Cls4U=",
+      "dev": true,
+      "requires": {
+        "application-config-path": "0.1.0",
+        "mkdirp": "0.5.1"
+      }
+    },
+    "application-config-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/application-config-path/-/application-config-path-0.1.0.tgz",
+      "integrity": "sha1-GTxfCoZUGkxm+6Hi3DhYM2LqXo8=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+    },
+    "asn1": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+      "integrity": "sha1-VZvhg3bQik7E2+gId9J4GGObLfc=",
+      "dev": true
+    },
+    "assert-plus": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+      "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "ast-types": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+    },
+    "async": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+      "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "asyncemit": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/asyncemit/-/asyncemit-3.0.1.tgz",
+      "integrity": "sha1-zD4P4No5tTzBXls6qGFupqcr1Zk="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz",
+      "integrity": "sha1-PYHKabR0seFlGHKLUcJP8Lvtxuk=",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+      "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "bacon.model": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/bacon.model/-/bacon.model-0.1.12.tgz",
+      "integrity": "sha1-H4swJKzMe0mVup1b8LjnQRviHYg=",
+      "requires": {
+        "baconjs": "0.7.95"
+      }
+    },
+    "baconjs": {
+      "version": "0.7.95",
+      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-0.7.95.tgz",
+      "integrity": "sha512-3qp0GuAfEUlJybSVPQ2oai8VYO0aSTJf4wP/jYZpgaffEXi31VBcqSlVmD8ahmXXGzgdO+yFk9onDnt2ZJJXxA=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "base62": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.0.tgz",
+      "integrity": "sha1-MeflYNyEbJ9EwaUx32UU2jVHQVc="
+    },
+    "basic-auth": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+      "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "tweetnacl": "0.14.5"
+      }
+    },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "bl": {
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.5.tgz",
+      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "bluebird": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
+    },
+    "body-parser": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
+      "requires": {
+        "bytes": "2.4.0",
+        "content-type": "1.0.2",
+        "debug": "2.6.7",
+        "depd": "1.1.1",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.15",
+        "on-finished": "2.3.0",
+        "qs": "6.4.0",
+        "raw-body": "2.2.0",
+        "type-is": "1.6.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+          "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "boom": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
+      "dev": true,
+      "requires": {
+        "hoek": "0.9.1"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+          "dev": true
+        }
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
+    "bytes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
+    },
+    "chai": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
+      "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.0.2",
+        "check-error": "1.0.2",
+        "deep-eql": "2.0.2",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.3"
+      }
+    },
+    "chai-things": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chai-things/-/chai-things-0.2.0.tgz",
+      "integrity": "sha1-xVEoN4+bs5nplPAAUhUZhO1uvnA=",
+      "dev": true
+    },
+    "chalk": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+      "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+      "requires": {
+        "ansi-styles": "1.0.0",
+        "has-color": "0.1.7",
+        "strip-ansi": "0.1.1"
+      }
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
+    },
+    "cjson": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cjson/-/cjson-0.3.0.tgz",
+      "integrity": "sha1-5kObkHA9MS/24iJAl76pLOPQKhQ=",
+      "requires": {
+        "jsonlint": "1.6.0"
+      }
+    },
+    "classnames": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
+      "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "color": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/color/-/color-0.8.0.tgz",
+      "integrity": "sha1-iQwHw/1OZJU3Y4kRz2keVFi2/KU=",
+      "requires": {
+        "color-convert": "0.5.3",
+        "color-string": "0.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+      "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+      "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "colornames": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz",
+      "integrity": "sha1-2BH9bIT1kClJmorEQ2ICk1uSvjE="
+    },
+    "colors": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+    },
+    "colorspace": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.0.1.tgz",
+      "integrity": "sha1-yZx5btMRKLmHalLh7l7gOkpxl0k=",
+      "requires": {
+        "color": "0.8.0",
+        "text-hex": "0.0.0"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+      "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+    },
+    "commoner": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
+      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
+      "requires": {
+        "commander": "2.11.0",
+        "detective": "4.5.0",
+        "glob": "5.0.15",
+        "graceful-fs": "4.1.11",
+        "iconv-lite": "0.4.15",
+        "mkdirp": "0.5.1",
+        "private": "0.1.7",
+        "q": "1.5.0",
+        "recast": "0.11.23"
+      }
+    },
+    "compare-versions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.0.1.tgz",
+      "integrity": "sha1-5gkVt/spTim7tghpGIdivuuHFEM="
+    },
+    "component-emitter": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+      "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "connected": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/connected/-/connected-0.0.2.tgz",
+      "integrity": "sha1-e1dVshbOMf+rzMOOn04d/Bw7fG0="
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-jar": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz",
+      "integrity": "sha1-vJon1OK5fhhs1XyeIGPLmfpozMw=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookiejar": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.1.tgz",
+      "integrity": "sha1-Qa1XsbVVlR7BcUEqgZQrHoIA00o="
+    },
+    "core-js": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.1"
+      }
+    },
+    "create-server": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/create-server/-/create-server-1.0.1.tgz",
+      "integrity": "sha1-FkNCg08Yi77Hx7xGZ0Y8wrEwTEQ=",
+      "requires": {
+        "connected": "0.0.2"
+      }
+    },
+    "cryptiles": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
+      "dev": true,
+      "requires": {
+        "boom": "0.4.2"
+      }
+    },
+    "ctype": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
+      "dev": true
+    },
+    "d3": {
+      "version": "3.5.17",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz",
+      "integrity": "sha1-vEZ0gAQ3iyGjYMn8fPUjF5B2L7g="
+    },
+    "d3-queue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/d3-queue/-/d3-queue-2.0.3.tgz",
+      "integrity": "sha1-B/vaOsrlNYqcUpmq+ICt8JU+0sI="
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "debug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.0.0.tgz",
+      "integrity": "sha512-XQkHxxqbsCb+zFurCHbotmJZl5jXsxvkRt952pT6Hpo7LmjWAJF12d9/kqBg5owjbLADbBDli1olravjSiSg8g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+      "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+      "dev": true,
+      "requires": {
+        "type-detect": "3.0.0"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+          "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
+          "dev": true
+        }
+      }
+    },
+    "deep-get-set": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/deep-get-set/-/deep-get-set-1.1.0.tgz",
+      "integrity": "sha1-R7uiAIo/3px1PcvmGjYkFgbZg28="
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "depd": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "detective": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "requires": {
+        "acorn": "4.0.13",
+        "defined": "1.0.0"
+      }
+    },
+    "dev-null-stream": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/dev-null-stream/-/dev-null-stream-0.0.1.tgz",
+      "integrity": "sha1-oqLie025mSjW2NRNXF9++9TLQ3I="
+    },
+    "diagnostics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.0.tgz",
+      "integrity": "sha1-4QkJALSVI+hSe+IPCBJ1IF8q42o=",
+      "requires": {
+        "colorspace": "1.0.1",
+        "enabled": "1.0.2",
+        "kuler": "0.0.0"
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+      "dev": true
+    },
+    "duplexer2": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+      "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "ebnf-parser": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/ebnf-parser/-/ebnf-parser-0.1.10.tgz",
+      "integrity": "sha1-zR9rpHfFY4xAyX7ZtXLbW6tdgzE="
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "jsbn": "0.1.1"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "ejson": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ejson/-/ejson-2.1.2.tgz",
+      "integrity": "sha1-Du1AVbx+DnVh/lnowyDtw/+M598=",
+      "requires": {
+        "underscore": "1.8.3"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.8.3",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+        }
+      }
+    },
+    "emits": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emits/-/emits-3.0.0.tgz",
+      "integrity": "sha1-MnUrupXhcHshlWI4Srm7ix/WL3A="
+    },
+    "enabled": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
+      "requires": {
+        "env-variable": "0.0.3"
+      }
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "requires": {
+        "iconv-lite": "0.4.15"
+      }
+    },
+    "env-variable": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz",
+      "integrity": "sha1-uGwWQb5WECZ9UG8YBx6nbXBwl8s="
+    },
+    "envify": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz",
+      "integrity": "sha1-1xIjKejfFoi6dxsSUBkXyc5cvOg=",
+      "requires": {
+        "jstransform": "11.0.3",
+        "through": "2.3.8"
+      }
+    },
+    "errorhandler": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.5.0.tgz",
+      "integrity": "sha1-6rpkyl1UKjEayUX1gt78M2Fl2fQ=",
+      "requires": {
+        "accepts": "1.3.3",
+        "escape-html": "1.0.3"
+      }
+    },
+    "es6-promise": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.1.1.tgz",
+      "integrity": "sha512-OaU1hHjgJf+b0NzsxCg7NdIYERD6Hy/PEmFLTjw+b65scuisG3Kt4QoTvJ66BBkPZ581gr0kpoVzKnxniM8nng=="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "escodegen": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.3.3.tgz",
+      "integrity": "sha1-8CQBb1qI4Eb9EgBQVek5gC5sXyM=",
+      "requires": {
+        "esprima": "1.1.1",
+        "estraverse": "1.5.1",
+        "esutils": "1.0.0",
+        "source-map": "0.1.43"
+      }
+    },
+    "esprima": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.1.1.tgz",
+      "integrity": "sha1-W28VR/TRAuZw4UDFCb5ncdautUk="
+    },
+    "estraverse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+      "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
+    },
+    "esutils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+      "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
+    },
+    "etag": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+    },
+    "eventemitter3": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+      "integrity": "sha1-teEHm1n7XhuidxwKmTvgYKWMmbo="
+    },
+    "express": {
+      "version": "4.15.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
+      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "requires": {
+        "accepts": "1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.8",
+        "depd": "1.1.1",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "finalhandler": "1.0.4",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "1.2.0",
+        "send": "0.15.4",
+        "serve-static": "1.12.4",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "1.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "qs": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
+        }
+      }
+    },
+    "express-namespace": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/express-namespace/-/express-namespace-0.1.1.tgz",
+      "integrity": "sha1-xJhQp0zqFu2UuoVjdAHYZsYbGfE=",
+      "requires": {
+        "methods": "0.0.1"
+      },
+      "dependencies": {
+        "methods": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
+          "integrity": "sha1-J3yQ+L7zlwlkWoNxxRw7bGSOBow="
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+    },
+    "extendible": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/extendible/-/extendible-0.1.1.tgz",
+      "integrity": "sha1-4qN+2HEp+0+VM+io11BiMKU5yQU="
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "fbjs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz",
+      "integrity": "sha1-lja3cF9bqWhNRLcveDISVK/IYPc=",
+      "requires": {
+        "core-js": "1.2.7",
+        "loose-envify": "1.3.1",
+        "promise": "7.3.1",
+        "ua-parser-js": "0.7.14",
+        "whatwg-fetch": "0.9.0"
+      }
+    },
+    "finalhandler": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
+      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "requires": {
+        "debug": "2.6.8",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "find-free-port": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/find-free-port/-/find-free-port-1.0.2.tgz",
+      "integrity": "sha1-uBfY8l03gzgXLHSqrJzkbgYdvto=",
+      "dev": true
+    },
+    "flatmap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/flatmap/-/flatmap-0.0.3.tgz",
+      "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
+    "forever-agent": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+      "integrity": "sha1-bQ4JxJIflKJ/Y9O0nF/v8epMUTA=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
+      "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.16"
+      }
+    },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
+    },
+    "formidable": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
+      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
+    },
+    "forwarded": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+    },
+    "forwarded-for": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/forwarded-for/-/forwarded-for-1.0.1.tgz",
+      "integrity": "sha1-59pIFAJRaP/AoQ0/954UFfRq9Gk="
+    },
+    "freeport-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/freeport-promise/-/freeport-promise-1.1.0.tgz",
+      "integrity": "sha1-MfrOgy6WQZjIBnecofRlhJzWcgs=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E="
+    },
+    "fusing": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fusing/-/fusing-1.0.0.tgz",
+      "integrity": "sha1-VQwV12r5Jld4qgUezkTUAAoJjUU=",
+      "requires": {
+        "emits": "3.0.0",
+        "predefine": "0.1.2"
+      }
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "ggencoder": {
+      "version": "0.1.18",
+      "resolved": "https://registry.npmjs.org/ggencoder/-/ggencoder-0.1.18.tgz",
+      "integrity": "sha1-sVlwp27o2JYOsSjJl82mk8YWCcE=",
+      "requires": {
+        "async": "2.5.0",
+        "jison": "0.4.17"
+      }
+    },
+    "ghauth": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ghauth/-/ghauth-3.0.0.tgz",
+      "integrity": "sha1-gpKiTvR4mfGAo5x4DEgJVhKUvbw=",
+      "dev": true,
+      "requires": {
+        "application-config": "0.1.2",
+        "bl": "0.9.5",
+        "hyperquest": "1.2.0",
+        "mkdirp": "0.5.1",
+        "read": "1.0.7",
+        "xtend": "4.0.1"
+      }
+    },
+    "github": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/github/-/github-0.1.16.tgz",
+      "integrity": "sha1-iV0qhbD+t5gNiawM5PRNyqA/F7U=",
+      "dev": true
+    },
+    "github-changes": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/github-changes/-/github-changes-1.1.0.tgz",
+      "integrity": "sha1-1Oi5i8N7Mv4nKuABcUFtbN9r/+4=",
+      "dev": true,
+      "requires": {
+        "bluebird": "1.0.3",
+        "ghauth": "3.0.0",
+        "github": "0.1.16",
+        "github-commit-stream": "0.1.0",
+        "lodash": "2.4.1",
+        "moment-timezone": "0.5.5",
+        "nomnom": "1.6.2",
+        "parse-link-header": "0.1.0",
+        "semver": "2.2.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.0.3.tgz",
+          "integrity": "sha1-xLRBGEgC47ZKYe7tRXgnG0yL9qw=",
+          "dev": true
+        },
+        "colors": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
+          "dev": true
+        },
+        "lodash": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+          "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=",
+          "dev": true
+        },
+        "nomnom": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
+          "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
+          "dev": true,
+          "requires": {
+            "colors": "0.5.1",
+            "underscore": "1.4.4"
+          }
+        },
+        "underscore": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
+          "dev": true
+        }
+      }
+    },
+    "github-commit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/github-commit-stream/-/github-commit-stream-0.1.0.tgz",
+      "integrity": "sha1-2823smeWcYa3DMc2ORgw2mNo16E=",
+      "dev": true,
+      "requires": {
+        "async": "0.2.10",
+        "parse-link-header": "0.1.0",
+        "request": "2.22.0",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+          "dev": true,
+          "requires": {
+            "delayed-stream": "0.0.5"
+          }
+        },
+        "delayed-stream": {
+          "version": "0.0.5",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+          "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz",
+          "integrity": "sha1-CJDNEAXFzOzAudJKiAUskkQtDbU=",
+          "dev": true,
+          "requires": {
+            "async": "0.2.10",
+            "combined-stream": "0.0.7",
+            "mime": "1.2.11"
+          }
+        },
+        "mime": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+          "dev": true
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+          "dev": true
+        },
+        "qs": {
+          "version": "0.6.6",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+          "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
+          "dev": true
+        },
+        "request": {
+          "version": "2.22.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.22.0.tgz",
+          "integrity": "sha1-uIOnacxKkJVx61AEs0TEPPflFZI=",
+          "dev": true,
+          "requires": {
+            "aws-sign": "0.3.0",
+            "cookie-jar": "0.3.0",
+            "forever-agent": "0.5.2",
+            "form-data": "0.0.8",
+            "hawk": "0.13.1",
+            "http-signature": "0.10.1",
+            "json-stringify-safe": "4.0.0",
+            "mime": "1.2.11",
+            "node-uuid": "1.4.8",
+            "oauth-sign": "0.3.0",
+            "qs": "0.6.6",
+            "tunnel-agent": "0.3.0"
+          }
+        }
+      }
+    },
+    "glob": {
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+      "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "har-schema": "1.0.5"
+      }
+    },
+    "has-color": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz",
+      "integrity": "sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8="
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "dev": true
+    },
+    "hawk": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz",
+      "integrity": "sha1-NheViCH1gxHk1/beKR/KZitBLvQ=",
+      "dev": true,
+      "requires": {
+        "boom": "0.4.2",
+        "cryptiles": "0.2.2",
+        "hoek": "0.8.5",
+        "sntp": "0.2.4"
+      }
+    },
+    "hoek": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.8.5.tgz",
+      "integrity": "sha1-Hp/XcO9+vgJ0rfy1sIBqAlpeTp8=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "requires": {
+        "depd": "1.1.1",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      }
+    },
+    "http-signature": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+      "integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.1.11",
+        "assert-plus": "0.1.5",
+        "ctype": "0.5.3"
+      }
+    },
+    "httpolyglot": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/httpolyglot/-/httpolyglot-0.1.2.tgz",
+      "integrity": "sha1-5NNH/omEpi9GfUBg31J/GFH2mXs="
+    },
+    "hyperquest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hyperquest/-/hyperquest-1.2.0.tgz",
+      "integrity": "sha1-OeH+9miI3Hzg3sbA3YFPb8iUStU=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.0.2",
+        "through2": "0.6.5"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "instrumentpanel": {
+      "version": "github:signalk/instrumentpanel#56146962cb2ecf14a3c3fa03fff15c30929abe2c",
+      "requires": {
+        "bacon.model": "0.1.12",
+        "baconjs": "0.7.95",
+        "bluebird": "2.11.0",
+        "d3": "3.5.17",
+        "debug": "2.6.8",
+        "js-quantities": "1.6.6",
+        "lodash": "2.4.2",
+        "react": "0.14.9",
+        "react-bootstrap": "0.13.3",
+        "react-dom": "0.14.9",
+        "react-fontawesome": "0.3.3",
+        "react-grid-layout": "0.10.9"
+      },
+      "dependencies": {
+        "@signalk/signalk-schema": {
+          "version": "github:SignalK/specification#c3d072f42893b56966ad43f2fcfc726dae995939",
+          "requires": {
+            "debug": "2.6.8",
+            "json-schema-ref-parser": "3.3.1",
+            "JSONStream": "0.7.4",
+            "lodash": "3.10.1",
+            "tv4": "1.3.0",
+            "tv4-formats": "2.2.2"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "3.10.1",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        }
+      }
+    },
+    "ipaddr.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+    },
+    "is": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/is/-/is-0.2.7.tgz",
+      "integrity": "sha1-OzSixI81mXLzUEKEkZOucmS2NWI=",
+      "dev": true
+    },
+    "is-object": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-0.1.2.tgz",
+      "integrity": "sha1-AO+8CIFsM8/ErIJR0TLhDcZQmNc=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "requires": {
+        "node-fetch": "1.7.2",
+        "whatwg-fetch": "2.0.3"
+      },
+      "dependencies": {
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
+      }
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "jison": {
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/jison/-/jison-0.4.17.tgz",
+      "integrity": "sha1-vBLUbFhF5v7onM81vSqMxz66F/M=",
+      "requires": {
+        "cjson": "0.3.0",
+        "ebnf-parser": "0.1.10",
+        "escodegen": "1.3.3",
+        "esprima": "1.1.1",
+        "jison-lex": "0.3.4",
+        "JSONSelect": "0.4.0",
+        "lex-parser": "0.1.4",
+        "nomnom": "1.5.2"
+      }
+    },
+    "jison-lex": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/jison-lex/-/jison-lex-0.3.4.tgz",
+      "integrity": "sha1-gcoo2E+ESZ36jFlNzePYo/Jux6U=",
+      "requires": {
+        "lex-parser": "0.1.4",
+        "nomnom": "1.5.2"
+      }
+    },
+    "jquery": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
+    },
+    "js-quantities": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/js-quantities/-/js-quantities-1.6.6.tgz",
+      "integrity": "sha1-dyLTAzDnbEbSwpzWY78Kpy1hXSw="
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "js-yaml": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
+      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        }
+      }
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
+      "optional": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
+    },
+    "json-schema-ref-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-3.3.1.tgz",
+      "integrity": "sha512-stQTMhec2R/p2L9dH4XXRlpNCP0mY8QrLd/9Kl+8SHJQmwHtE1nDfXH4wbsSM+GkJMl8t92yZbI0OIol432CIQ==",
+      "requires": {
+        "call-me-maybe": "1.0.1",
+        "debug": "3.0.0",
+        "es6-promise": "4.1.1",
+        "js-yaml": "3.9.1",
+        "ono": "4.0.2",
+        "z-schema": "3.18.3"
+      }
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "json-stringify-safe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-4.0.0.tgz",
+      "integrity": "sha1-d8JxqupUMC5o7+rMtWq78GqbGlQ=",
+      "dev": true
+    },
+    "json3": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+      "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+      "dev": true
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonlint": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jsonlint/-/jsonlint-1.6.0.tgz",
+      "integrity": "sha1-iKpGvCiaesk7tGyuLVihh6m7SUo=",
+      "requires": {
+        "JSV": "4.0.2",
+        "nomnom": "1.5.2"
+      }
+    },
+    "jsonparse": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+      "integrity": "sha1-MwVCrT8KZUZlt3jz6y2an6UHrGQ="
+    },
+    "JSONSelect": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
+      "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40="
+    },
+    "JSONStream": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+      "integrity": "sha1-c0KQ5BUR7qfCz+FR+/mlY6l7l4Y=",
+      "requires": {
+        "jsonparse": "0.0.5",
+        "through": "2.3.8"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "jstransform": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
+      "requires": {
+        "base62": "1.2.0",
+        "commoner": "0.10.8",
+        "esprima-fb": "15001.1.0-dev-harmony-fb",
+        "object-assign": "2.1.1",
+        "source-map": "0.4.4"
+      },
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1.0-dev-harmony-fb",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
+          "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
+    },
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
+    },
+    "kuler": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz",
+      "integrity": "sha1-tmu0a5NOVQ9Z2BiEjgq7pPf1VTw=",
+      "requires": {
+        "colornames": "0.0.2"
+      }
+    },
+    "leaflet": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-0.7.7.tgz",
+      "integrity": "sha1-HjUrpU5j0HZFH6NjyQCJDLLPde4="
+    },
+    "lex-parser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/lex-parser/-/lex-parser-0.1.4.tgz",
+      "integrity": "sha1-ZMTwJfF/1Tv7RXY/rrFvAVp0dVA="
+    },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+      "requires": {
+        "immediate": "3.0.6"
+      }
+    },
+    "limiter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.2.tgz",
+      "integrity": "sha512-JIKZ0xb6fZZYa3deZ0BgXCgX6HgV8Nx3mFGeFHmFWW8Fb2c08e0CyE+G3nalpD0xGvGssjGb1UdFr+PprxZEbw=="
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "dev": true,
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+      "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+      "dev": true
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE=",
+      "dev": true
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+      "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+      "dev": true
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+      "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+      "dev": true
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
+      "dev": true,
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._basecreate": "3.0.3",
+        "lodash._isiterateecall": "3.0.9"
+      }
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+      "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+      "dev": true
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+      "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "dev": true,
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "maptracker": {
+      "version": "github:signalk/maptracker#d2822bb7c51194d8d006878b850aa6464d29a4c4",
+      "requires": {
+        "d3": "3.5.17",
+        "jquery": "2.2.4",
+        "js-quantities": "1.6.6",
+        "leaflet": "0.7.7"
+      },
+      "dependencies": {
+        "@signalk/client": {
+          "version": "github:signalk/signalk-js-client#9be79353d8ef75cf5d6f9018c9c8e49b386e7a12",
+          "requires": {
+            "bluebird": "3.5.0",
+            "debug": "3.0.0",
+            "eventemitter3": "2.0.3",
+            "lodash": "4.17.4",
+            "superagent": "3.5.2",
+            "superagent-promise": "1.1.0",
+            "url": "0.11.0",
+            "ws": "3.1.0"
+          }
+        },
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+        }
+      }
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "millisecond": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/millisecond/-/millisecond-0.1.2.tgz",
+      "integrity": "sha1-bMWtOGJByrjniv+WT4cCjuyS2sU="
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+    },
+    "mime-db": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+    },
+    "mime-types": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "requires": {
+        "mime-db": "1.29.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "mocha": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
+      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "dev": true,
+      "requires": {
+        "browser-stdout": "1.3.0",
+        "commander": "2.9.0",
+        "debug": "2.6.8",
+        "diff": "3.2.0",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.1",
+        "growl": "1.9.2",
+        "json3": "3.3.2",
+        "lodash.create": "3.1.1",
+        "mkdirp": "0.5.1",
+        "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+          "dev": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "moment": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
+      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+    },
+    "moment-timezone": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.5.tgz",
+      "integrity": "sha1-odVBCnLBil8pPyouYocKgK1DLa4=",
+      "dev": true,
+      "requires": {
+        "moment": "2.18.1"
+      }
+    },
+    "morgan": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.8.2.tgz",
+      "integrity": "sha1-eErHc05KRTqcbm6GgKkyknXItoc=",
+      "requires": {
+        "basic-auth": "1.1.0",
+        "debug": "2.6.8",
+        "depd": "1.1.1",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "n2k-signalk": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/n2k-signalk/-/n2k-signalk-0.0.3.tgz",
+      "integrity": "sha1-1zynkaow7+F702T3KF5UgatN86w=",
+      "requires": {
+        "@signalk/signalk-schema": "0.0.1-4",
+        "debug": "3.0.0",
+        "JSONStream": "1.3.1",
+        "nomnom": "1.8.1",
+        "through": "2.3.8"
+      },
+      "dependencies": {
+        "@signalk/signalk-schema": {
+          "version": "0.0.1-4",
+          "resolved": "https://registry.npmjs.org/@signalk/signalk-schema/-/signalk-schema-0.0.1-4.tgz",
+          "integrity": "sha1-YAUWsM9v+J11tyw5gr7LbeILlo8=",
+          "requires": {
+            "debug": "2.6.8",
+            "json-schema-ref-parser": "3.3.1",
+            "JSONStream": "0.7.4",
+            "lodash": "3.10.1",
+            "tv4": "1.3.0",
+            "tv4-formats": "2.2.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "JSONStream": {
+              "version": "0.7.4",
+              "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.7.4.tgz",
+              "integrity": "sha1-c0KQ5BUR7qfCz+FR+/mlY6l7l4Y=",
+              "requires": {
+                "jsonparse": "0.0.5",
+                "through": "2.3.8"
+              }
+            }
+          }
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+          "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+              "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        },
+        "nomnom": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
+          "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+          "requires": {
+            "chalk": "0.4.0",
+            "underscore": "1.6.0"
+          }
+        },
+        "underscore": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+        }
+      }
+    },
+    "nan": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.6.2.tgz",
+      "integrity": "sha1-5P805slf37WuzAjeZZb0NgWn20U="
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "nmea0183-signalk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/nmea0183-signalk/-/nmea0183-signalk-0.5.0.tgz",
+      "integrity": "sha1-UTXz2SZIx9syORq9IeSHKEHmQ2A=",
+      "requires": {
+        "ggencoder": "0.1.18",
+        "lodash": "4.17.4",
+        "signalk-multiplexer": "git://github.com/SignalK/signalk-multiplexer-node.git#67ddd0e67c625aec257fc31ea3c65fb5edd15c95",
+        "uuid": "3.1.0"
+      }
+    },
+    "node-fetch": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.2.tgz",
+      "integrity": "sha512-xZZUq2yDhKMIn/UgG5q//IZSNLJIwW2QxS14CNH5spuiXkITM2pUitjdq58yLSaU7m4M0wBNaM2Gh/ggY4YJig==",
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
+    },
+    "node-gpsd": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-gpsd/-/node-gpsd-0.3.0.tgz",
+      "integrity": "sha1-RjerBRfXAYyCDtHTM/zirPaBw9U="
+    },
+    "nomnom": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.5.2.tgz",
+      "integrity": "sha1-9DRUSKhTz71cDSYyDyR3qwUm/i8=",
+      "requires": {
+        "colors": "0.5.1",
+        "underscore": "1.1.7"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
+          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q="
+        }
+      }
+    },
+    "oauth-sign": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+      "integrity": "sha1-y1QPk7srIqfVlBaRoojWDo6pOG4=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.0",
+        "object-keys": "1.0.11"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "ono": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.2.tgz",
+      "integrity": "sha512-EFXJFoeF+KkZW4lwmcPMKHp2ZU7o6CM+ccX2nPbEJKiJIdyqbIcS1v6pmNgeNJ6x4/vEYn0/8oz66qXSPnnmSQ==",
+      "requires": {
+        "format-util": "1.0.3"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "parse-link-header": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-0.1.0.tgz",
+      "integrity": "sha1-VQP6f7LzVLsjQlXBxCHaPrBbkYU=",
+      "dev": true,
+      "requires": {
+        "xtend": "2.0.6"
+      },
+      "dependencies": {
+        "object-keys": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.2.0.tgz",
+          "integrity": "sha1-zd7AKZiwkb5CvxA1rjLknxy26mc=",
+          "dev": true,
+          "requires": {
+            "foreach": "2.0.5",
+            "indexof": "0.0.1",
+            "is": "0.2.7"
+          }
+        },
+        "xtend": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.0.6.tgz",
+          "integrity": "sha1-XqZXptukRwacLlnFihE4ywxebO4=",
+          "dev": true,
+          "requires": {
+            "is-object": "0.1.2",
+            "object-keys": "0.2.0"
+          }
+        }
+      }
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
+    },
+    "pem": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.9.7.tgz",
+      "integrity": "sha1-04f5lvKSx8nepjmlNYBedMtQMWE=",
+      "requires": {
+        "os-tmpdir": "1.0.2",
+        "which": "1.3.0"
+      }
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
+      "dev": true
+    },
+    "predefine": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/predefine/-/predefine-0.1.2.tgz",
+      "integrity": "sha1-KqkrRJa8H4VU5DpF92v75Q0z038=",
+      "requires": {
+        "extendible": "0.1.1"
+      }
+    },
+    "primus": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/primus/-/primus-7.1.0.tgz",
+      "integrity": "sha512-E2J5nvnmNuUTsfJMhxV5oQChJ0DXGZm0WlKxM0XZRnAfgqgkbVntANiPBA+2BNiccrNz+aeZlIS9on+lP5CW7g==",
+      "requires": {
+        "access-control": "1.0.0",
+        "asyncemit": "3.0.1",
+        "create-server": "1.0.1",
+        "diagnostics": "1.1.0",
+        "eventemitter3": "2.0.3",
+        "forwarded-for": "1.0.1",
+        "fusing": "1.0.0",
+        "setheader": "0.0.4",
+        "ultron": "1.1.0",
+        "yeast": "0.1.2"
+      }
+    },
+    "private": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.5.10",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+      "integrity": "sha1-J5ffwxJhguOpXj37suiT3ddFYVQ=",
+      "requires": {
+        "fbjs": "0.8.14",
+        "loose-envify": "1.3.1"
+      },
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.14",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
+          "integrity": "sha1-0dviviVMNakeCfMfnNUKQLKg7Rw=",
+          "requires": {
+            "core-js": "1.2.7",
+            "isomorphic-fetch": "2.2.1",
+            "loose-envify": "1.3.1",
+            "object-assign": "4.1.1",
+            "promise": "7.3.1",
+            "setimmediate": "1.0.5",
+            "ua-parser-js": "0.7.14"
+          }
+        }
+      }
+    },
+    "proxy-addr": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "requires": {
+        "forwarded": "0.1.0",
+        "ipaddr.js": "1.4.0"
+      }
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "q": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
+      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+      "requires": {
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
+        "unpipe": "1.0.0"
+      }
+    },
+    "react": {
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.14.9.tgz",
+      "integrity": "sha1-kRCmSXxJ1EuhwO3TF67CnC4NkdE=",
+      "requires": {
+        "envify": "3.4.1",
+        "fbjs": "0.6.1"
+      }
+    },
+    "react-bootstrap": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.13.3.tgz",
+      "integrity": "sha1-ug25Uz2oS6zmVGces3UCIR6hlrE="
+    },
+    "react-dom": {
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.9.tgz",
+      "integrity": "sha1-BQZKPc8PsYgKOyv8nVjFXY2fYpM="
+    },
+    "react-draggable": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-1.3.7.tgz",
+      "integrity": "sha1-cpveS9HnF8OVsijHdeg3aV1QwrI=",
+      "requires": {
+        "classnames": "2.2.5"
+      }
+    },
+    "react-fontawesome": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-0.3.3.tgz",
+      "integrity": "sha1-b6E7oF44EjyIL9SFd9GCxFz+hn4="
+    },
+    "react-grid-layout": {
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/react-grid-layout/-/react-grid-layout-0.10.9.tgz",
+      "integrity": "sha1-tyHCIR1mQKVKGFdM5NoycbSwfTo=",
+      "requires": {
+        "lodash.isequal": "4.5.0",
+        "react-draggable": "1.3.7",
+        "react-resizable": "1.7.1"
+      }
+    },
+    "react-resizable": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.7.1.tgz",
+      "integrity": "sha1-6P0sIkfJKZ0Rf7JF2+7ZxowOAEw=",
+      "requires": {
+        "prop-types": "15.5.10",
+        "react-draggable": "2.2.6"
+      },
+      "dependencies": {
+        "react-draggable": {
+          "version": "2.2.6",
+          "resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-2.2.6.tgz",
+          "integrity": "sha1-OoBuEPLaa6v+pBNr5lEOibDXaQE=",
+          "requires": {
+            "classnames": "2.2.5"
+          }
+        }
+      }
+    },
+    "read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "dev": true,
+      "requires": {
+        "mute-stream": "0.0.7"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "recast": {
+      "version": "0.11.23",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
+      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
+      "requires": {
+        "ast-types": "0.9.6",
+        "esprima": "3.1.3",
+        "private": "0.1.7",
+        "source-map": "0.5.6"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "request": {
+      "version": "2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+      "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "0.6.0",
+        "aws4": "1.6.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.5",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.1.4",
+        "har-validator": "4.2.1",
+        "hawk": "3.1.3",
+        "http-signature": "1.1.1",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.16",
+        "oauth-sign": "0.8.2",
+        "performance-now": "0.2.0",
+        "qs": "6.4.0",
+        "safe-buffer": "5.1.1",
+        "stringstream": "0.0.5",
+        "tough-cookie": "2.3.2",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.1.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+          "dev": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+          "dev": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.16"
+          }
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+          "dev": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+          "dev": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.13.1"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+          "dev": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.1.1"
+          }
+        }
+      }
+    },
+    "request-promise": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.1.tgz",
+      "integrity": "sha1-fuxWyJMXqCLL/qmbA5zlQ8LhX2c=",
+      "dev": true,
+      "requires": {
+        "bluebird": "3.5.0",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.2"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+          "dev": true
+        }
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "rotating-file-stream": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rotating-file-stream/-/rotating-file-stream-1.2.2.tgz",
+      "integrity": "sha1-KSpfB9yZsfxP9ArG6MyupumWH24="
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "semver": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz",
+      "integrity": "sha1-eUEYKz/8xYC/8cF5QqzfeVHA0hM=",
+      "dev": true
+    },
+    "send": {
+      "version": "0.15.4",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+      "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+      "requires": {
+        "debug": "2.6.8",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "1.6.2",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "serialport": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/serialport/-/serialport-4.0.7.tgz",
+      "integrity": "sha1-QhxhiophK9QM+kYbSkYVTa8iKaU=",
+      "requires": {
+        "bindings": "1.2.1",
+        "commander": "2.11.0",
+        "debug": "2.6.8",
+        "lie": "3.1.1",
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.32",
+        "object.assign": "4.0.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "node-pre-gyp": {
+          "version": "0.6.32",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "3.0.6",
+            "npmlog": "4.0.1",
+            "rc": "1.1.6",
+            "request": "2.79.0",
+            "rimraf": "2.5.4",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.3.0"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.0.9"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.9",
+                  "bundled": true
+                }
+              }
+            },
+            "npmlog": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "are-we-there-yet": "1.1.2",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.2",
+                "set-blocking": "2.0.0"
+              },
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.2.2"
+                  },
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "readable-stream": {
+                      "version": "2.2.2",
+                      "bundled": true,
+                      "requires": {
+                        "buffer-shims": "1.0.0",
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "string_decoder": "0.10.31",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "buffer-shims": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "bundled": true
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "gauge": {
+                  "version": "2.7.2",
+                  "bundled": true,
+                  "requires": {
+                    "aproba": "1.0.4",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.0",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "supports-color": "0.2.0",
+                    "wide-align": "1.1.0"
+                  },
+                  "dependencies": {
+                    "aproba": {
+                      "version": "1.0.4",
+                      "bundled": true
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "bundled": true
+                    },
+                    "object-assign": {
+                      "version": "4.1.0",
+                      "bundled": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2",
+                      "bundled": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    },
+                    "wide-align": {
+                      "version": "1.1.0",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "rc": {
+              "version": "1.1.6",
+              "bundled": true,
+              "requires": {
+                "deep-extend": "0.4.1",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "1.0.4"
+              },
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.4.1",
+                  "bundled": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "bundled": true
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "strip-json-comments": {
+                  "version": "1.0.4",
+                  "bundled": true
+                }
+              }
+            },
+            "request": {
+              "version": "2.79.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.5.0",
+                "caseless": "0.11.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.0",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.2",
+                "har-validator": "2.0.6",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.13",
+                "oauth-sign": "0.8.2",
+                "qs": "6.3.0",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.4.3",
+                "uuid": "3.0.1"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true
+                },
+                "aws4": {
+                  "version": "1.5.0",
+                  "bundled": true
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "bundled": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "2.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.13"
+                  },
+                  "dependencies": {
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "bundled": true,
+                  "requires": {
+                    "chalk": "1.1.3",
+                    "commander": "2.11.0",
+                    "is-my-json-valid": "2.15.0",
+                    "pinkie-promise": "2.0.1"
+                  },
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                      },
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "bundled": true
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "bundled": true
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "ansi-regex": "2.0.0"
+                          },
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.0.0",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "bundled": true,
+                      "requires": {
+                        "generate-function": "2.0.0",
+                        "generate-object-property": "1.2.0",
+                        "jsonpointer": "4.0.0",
+                        "xtend": "4.0.1"
+                      },
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "bundled": true
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "bundled": true,
+                          "requires": {
+                            "is-property": "1.0.2"
+                          },
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "4.0.0",
+                          "bundled": true
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "pinkie": "2.0.4"
+                      },
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.3.1",
+                    "sshpk": "1.10.1"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    },
+                    "jsprim": {
+                      "version": "1.3.1",
+                      "bundled": true,
+                      "requires": {
+                        "extsprintf": "1.0.2",
+                        "json-schema": "0.2.3",
+                        "verror": "1.3.6"
+                      },
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "bundled": true,
+                          "requires": {
+                            "extsprintf": "1.0.2"
+                          }
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.1",
+                      "bundled": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.0",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.6",
+                        "jodid25519": "1.0.2",
+                        "jsbn": "0.1.0",
+                        "tweetnacl": "0.14.4"
+                      },
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.4"
+                          }
+                        },
+                        "dashdash": {
+                          "version": "1.14.1",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "bundled": true,
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "getpass": {
+                          "version": "0.1.6",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "bundled": true,
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.0"
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "bundled": true,
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.4",
+                          "bundled": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.1.13",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.25.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.25.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true
+                },
+                "qs": {
+                  "version": "6.3.0",
+                  "bundled": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.4.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.3",
+                  "bundled": true
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.5.4",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.1"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "7.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "bundled": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.10",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                },
+                "fstream": {
+                  "version": "1.0.10",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.5.4"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "bundled": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "tar-pack": {
+              "version": "3.3.0",
+              "bundled": true,
+              "requires": {
+                "debug": "2.2.0",
+                "fstream": "1.0.10",
+                "fstream-ignore": "1.0.5",
+                "once": "1.3.3",
+                "readable-stream": "2.1.5",
+                "rimraf": "2.5.4",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.2.0",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "0.7.1"
+                  },
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "fstream": {
+                  "version": "1.0.10",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.5.4"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "bundled": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "fstream": "1.0.10",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.3"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.6"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.6",
+                          "bundled": true,
+                          "requires": {
+                            "balanced-match": "0.4.2",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.4.2",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.1.5",
+                  "bundled": true,
+                  "requires": {
+                    "buffer-shims": "1.0.0",
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "string_decoder": "0.10.31",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "bundled": true
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "serve-static": {
+      "version": "1.12.4",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
+      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
+        "send": "0.15.4"
+      }
+    },
+    "set-system-time": {
+      "version": "github:tkurki/set-system-time#691d33a6272e768692e7849d258d408b8dcf25c1"
+    },
+    "setheader": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/setheader/-/setheader-0.0.4.tgz",
+      "integrity": "sha1-km7SjPdiFJYgkx566j8blYFuxpQ=",
+      "requires": {
+        "debug": "0.7.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "0.7.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
+        }
+      }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+    },
+    "signalk-client": {
+      "version": "0.0.1-4",
+      "resolved": "https://registry.npmjs.org/signalk-client/-/signalk-client-0.0.1-4.tgz",
+      "integrity": "sha1-W+p/XqdM76Iuayied9fxTRm5mIU=",
+      "requires": {
+        "bluebird": "3.5.0",
+        "debug": "2.6.8",
+        "eventemitter3": "2.0.3",
+        "lodash": "4.17.4",
+        "superagent": "3.5.2",
+        "superagent-promise": "1.1.0",
+        "url": "0.11.0",
+        "ws": "2.3.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+          "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+        },
+        "ws": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+          "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
+          "requires": {
+            "safe-buffer": "5.0.1",
+            "ultron": "1.1.0"
+          }
+        }
+      }
+    },
+    "signalk-multiplexer": {
+      "version": "git://github.com/SignalK/signalk-multiplexer-node.git#67ddd0e67c625aec257fc31ea3c65fb5edd15c95",
+      "requires": {
+        "debug": "2.6.8",
+        "lodash": "2.4.2",
+        "node-uuid": "1.4.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+        }
+      }
+    },
+    "signalk-playground": {
+      "version": "github:signalk/playground#85a175fe930153d9e2e5f950535e2562cee8bc93"
+    },
+    "signalk-schema": {
+      "version": "0.0.1-3",
+      "resolved": "https://registry.npmjs.org/signalk-schema/-/signalk-schema-0.0.1-3.tgz",
+      "integrity": "sha1-bmMatpluMgt9EyQydVFCLY0ComI=",
+      "requires": {
+        "debug": "2.6.8",
+        "json-schema-ref-parser": "3.3.1",
+        "JSONStream": "0.7.4",
+        "lodash": "3.10.1",
+        "tv4": "1.3.0",
+        "tv4-formats": "2.2.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
+    },
+    "signalk-zones": {
+      "version": "github:signalk/signalk-zones#e8a4e738e73f8ed89abfce9214839c7047966f3d",
+      "requires": {
+        "@signalk/signalk-schema": "0.0.1-6",
+        "baconjs": "0.7.95"
+      },
+      "dependencies": {
+        "@signalk/signalk-schema": {
+          "version": "0.0.1-6",
+          "resolved": "https://registry.npmjs.org/@signalk/signalk-schema/-/signalk-schema-0.0.1-6.tgz",
+          "integrity": "sha1-B/FPpasG0huhd4kLPjqt269pU6I=",
+          "requires": {
+            "debug": "2.6.8",
+            "json-schema-ref-parser": "3.3.1",
+            "JSONStream": "0.7.4",
+            "lodash": "3.10.1",
+            "tv4": "1.3.0",
+            "tv4-formats": "2.2.2"
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
+      }
+    },
+    "sntp": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
+      "dev": true,
+      "requires": {
+        "hoek": "0.9.1"
+      },
+      "dependencies": {
+        "hoek": {
+          "version": "0.9.1",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
+          "dev": true
+        }
+      }
+    },
+    "source-map": {
+      "version": "0.1.43",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+      "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
+    },
+    "split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "requires": {
+        "through": "2.3.8"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sqlite3": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-3.1.9.tgz",
+      "integrity": "sha1-suf7qjSDgDGNODQyORjDw1G4vxg=",
+      "requires": {
+        "nan": "2.6.2",
+        "node-pre-gyp": "0.6.36"
+      },
+      "dependencies": {
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.2",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.4.1",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          },
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "bundled": true
+                }
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
+              },
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "osenv": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "os-homedir": "1.0.2",
+                    "os-tmpdir": "1.0.2"
+                  },
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              },
+              "dependencies": {
+                "are-we-there-yet": {
+                  "version": "1.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "delegates": "1.0.0",
+                    "readable-stream": "2.3.3"
+                  },
+                  "dependencies": {
+                    "delegates": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "readable-stream": {
+                      "version": "2.3.3",
+                      "bundled": true,
+                      "requires": {
+                        "core-util-is": "1.0.2",
+                        "inherits": "2.0.3",
+                        "isarray": "1.0.0",
+                        "process-nextick-args": "1.0.7",
+                        "safe-buffer": "5.1.1",
+                        "string_decoder": "1.0.3",
+                        "util-deprecate": "1.0.2"
+                      },
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        },
+                        "inherits": {
+                          "version": "2.0.3",
+                          "bundled": true
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "bundled": true
+                        },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "bundled": true
+                        },
+                        "string_decoder": {
+                          "version": "1.0.3",
+                          "bundled": true,
+                          "requires": {
+                            "safe-buffer": "5.1.1"
+                          }
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "console-control-strings": {
+                  "version": "1.1.0",
+                  "bundled": true
+                },
+                "gauge": {
+                  "version": "2.7.4",
+                  "bundled": true,
+                  "requires": {
+                    "aproba": "1.1.2",
+                    "console-control-strings": "1.1.0",
+                    "has-unicode": "2.0.1",
+                    "object-assign": "4.1.1",
+                    "signal-exit": "3.0.2",
+                    "string-width": "1.0.2",
+                    "strip-ansi": "3.0.1",
+                    "wide-align": "1.1.2"
+                  },
+                  "dependencies": {
+                    "aproba": {
+                      "version": "1.1.2",
+                      "bundled": true
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "bundled": true
+                    },
+                    "object-assign": {
+                      "version": "4.1.1",
+                      "bundled": true
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2",
+                      "bundled": true
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "bundled": true,
+                      "requires": {
+                        "code-point-at": "1.1.0",
+                        "is-fullwidth-code-point": "1.0.0",
+                        "strip-ansi": "3.0.1"
+                      },
+                      "dependencies": {
+                        "code-point-at": {
+                          "version": "1.1.0",
+                          "bundled": true
+                        },
+                        "is-fullwidth-code-point": {
+                          "version": "1.0.0",
+                          "bundled": true,
+                          "requires": {
+                            "number-is-nan": "1.0.1"
+                          },
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "bundled": true,
+                      "requires": {
+                        "ansi-regex": "2.1.1"
+                      },
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "wide-align": {
+                      "version": "1.1.2",
+                      "bundled": true,
+                      "requires": {
+                        "string-width": "1.0.2"
+                      }
+                    }
+                  }
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "bundled": true
+                }
+              }
+            },
+            "rc": {
+              "version": "1.2.1",
+              "bundled": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              },
+              "dependencies": {
+                "deep-extend": {
+                  "version": "0.4.2",
+                  "bundled": true
+                },
+                "ini": {
+                  "version": "1.3.4",
+                  "bundled": true
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true
+                },
+                "strip-json-comments": {
+                  "version": "2.0.1",
+                  "bundled": true
+                }
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.16",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.1.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.1.0"
+              },
+              "dependencies": {
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "bundled": true
+                },
+                "aws4": {
+                  "version": "1.6.0",
+                  "bundled": true
+                },
+                "caseless": {
+                  "version": "0.12.0",
+                  "bundled": true
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "delayed-stream": "1.0.0"
+                  },
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.1",
+                  "bundled": true
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "bundled": true
+                },
+                "form-data": {
+                  "version": "2.1.4",
+                  "bundled": true,
+                  "requires": {
+                    "asynckit": "0.4.0",
+                    "combined-stream": "1.0.5",
+                    "mime-types": "2.1.16"
+                  },
+                  "dependencies": {
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "4.2.1",
+                  "bundled": true,
+                  "requires": {
+                    "ajv": "4.11.8",
+                    "har-schema": "1.0.5"
+                  },
+                  "dependencies": {
+                    "ajv": {
+                      "version": "4.11.8",
+                      "bundled": true,
+                      "requires": {
+                        "co": "4.6.0",
+                        "json-stable-stringify": "1.0.1"
+                      },
+                      "dependencies": {
+                        "co": {
+                          "version": "4.6.0",
+                          "bundled": true
+                        },
+                        "json-stable-stringify": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "requires": {
+                            "jsonify": "0.0.0"
+                          },
+                          "dependencies": {
+                            "jsonify": {
+                              "version": "0.0.0",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "har-schema": {
+                      "version": "1.0.5",
+                      "bundled": true
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "bundled": true,
+                  "requires": {
+                    "boom": "2.10.1",
+                    "cryptiles": "2.0.5",
+                    "hoek": "2.16.3",
+                    "sntp": "1.0.9"
+                  },
+                  "dependencies": {
+                    "boom": {
+                      "version": "2.10.1",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "bundled": true,
+                      "requires": {
+                        "boom": "2.10.1"
+                      }
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "bundled": true
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "bundled": true,
+                      "requires": {
+                        "hoek": "2.16.3"
+                      }
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "bundled": true,
+                  "requires": {
+                    "assert-plus": "0.2.0",
+                    "jsprim": "1.4.1",
+                    "sshpk": "1.13.1"
+                  },
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "bundled": true
+                    },
+                    "jsprim": {
+                      "version": "1.4.1",
+                      "bundled": true,
+                      "requires": {
+                        "assert-plus": "1.0.0",
+                        "extsprintf": "1.3.0",
+                        "json-schema": "0.2.3",
+                        "verror": "1.10.0"
+                      },
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "extsprintf": {
+                          "version": "1.3.0",
+                          "bundled": true
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "verror": {
+                          "version": "1.10.0",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0",
+                            "core-util-is": "1.0.2",
+                            "extsprintf": "1.3.0"
+                          },
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.13.1",
+                      "bundled": true,
+                      "requires": {
+                        "asn1": "0.2.3",
+                        "assert-plus": "1.0.0",
+                        "bcrypt-pbkdf": "1.0.1",
+                        "dashdash": "1.14.1",
+                        "ecc-jsbn": "0.1.1",
+                        "getpass": "0.1.7",
+                        "jsbn": "0.1.1",
+                        "tweetnacl": "0.14.5"
+                      },
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "bundled": true
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "bundled": true
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.1",
+                          "bundled": true,
+                          "optional": true,
+                          "requires": {
+                            "tweetnacl": "0.14.5"
+                          }
+                        },
+                        "dashdash": {
+                          "version": "1.14.1",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "bundled": true,
+                          "optional": true,
+                          "requires": {
+                            "jsbn": "0.1.1"
+                          }
+                        },
+                        "getpass": {
+                          "version": "0.1.7",
+                          "bundled": true,
+                          "requires": {
+                            "assert-plus": "1.0.0"
+                          }
+                        },
+                        "jsbn": {
+                          "version": "0.1.1",
+                          "bundled": true,
+                          "optional": true
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.5",
+                          "bundled": true,
+                          "optional": true
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "bundled": true
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "bundled": true
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "bundled": true
+                },
+                "mime-types": {
+                  "version": "2.1.16",
+                  "bundled": true,
+                  "requires": {
+                    "mime-db": "1.29.0"
+                  },
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.29.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "bundled": true
+                },
+                "performance-now": {
+                  "version": "0.2.0",
+                  "bundled": true
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "bundled": true
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "bundled": true
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "bundled": true
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "bundled": true,
+                  "requires": {
+                    "punycode": "1.4.1"
+                  },
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.4.1",
+                      "bundled": true
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.6.0",
+                  "bundled": true,
+                  "requires": {
+                    "safe-buffer": "5.1.1"
+                  }
+                },
+                "uuid": {
+                  "version": "3.1.0",
+                  "bundled": true
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              },
+              "dependencies": {
+                "glob": {
+                  "version": "7.1.2",
+                  "bundled": true,
+                  "requires": {
+                    "fs.realpath": "1.0.0",
+                    "inflight": "1.0.6",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4",
+                    "once": "1.4.0",
+                    "path-is-absolute": "1.0.1"
+                  },
+                  "dependencies": {
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "bundled": true,
+                      "requires": {
+                        "once": "1.4.0",
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.8"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.8",
+                          "bundled": true,
+                          "requires": {
+                            "balanced-match": "1.0.0",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "bundled": true,
+                      "requires": {
+                        "wrappy": "1.0.2"
+                      },
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "bundled": true
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "bundled": true
+                    }
+                  }
+                }
+              }
+            },
+            "semver": {
+              "version": "5.4.1",
+              "bundled": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              },
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "bundled": true,
+                  "requires": {
+                    "inherits": "2.0.3"
+                  }
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "bundled": true
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "bundled": true
+                }
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "bundled": true,
+              "requires": {
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.3.3",
+                "rimraf": "2.6.1",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              },
+              "dependencies": {
+                "debug": {
+                  "version": "2.6.8",
+                  "bundled": true,
+                  "requires": {
+                    "ms": "2.0.0"
+                  },
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "bundled": true
+                    }
+                  }
+                },
+                "fstream": {
+                  "version": "1.0.11",
+                  "bundled": true,
+                  "requires": {
+                    "graceful-fs": "4.1.11",
+                    "inherits": "2.0.3",
+                    "mkdirp": "0.5.1",
+                    "rimraf": "2.6.1"
+                  },
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "bundled": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    }
+                  }
+                },
+                "fstream-ignore": {
+                  "version": "1.0.5",
+                  "bundled": true,
+                  "requires": {
+                    "fstream": "1.0.11",
+                    "inherits": "2.0.3",
+                    "minimatch": "3.0.4"
+                  },
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "bundled": true,
+                      "requires": {
+                        "brace-expansion": "1.1.8"
+                      },
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.8",
+                          "bundled": true,
+                          "requires": {
+                            "balanced-match": "1.0.0",
+                            "concat-map": "0.0.1"
+                          },
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "1.0.0",
+                              "bundled": true
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "bundled": true
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.4.0",
+                  "bundled": true,
+                  "requires": {
+                    "wrappy": "1.0.2"
+                  },
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.3.3",
+                  "bundled": true,
+                  "requires": {
+                    "core-util-is": "1.0.2",
+                    "inherits": "2.0.3",
+                    "isarray": "1.0.0",
+                    "process-nextick-args": "1.0.7",
+                    "safe-buffer": "5.1.1",
+                    "string_decoder": "1.0.3",
+                    "util-deprecate": "1.0.2"
+                  },
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "bundled": true
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "bundled": true
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "bundled": true
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "bundled": true
+                    },
+                    "string_decoder": {
+                      "version": "1.0.3",
+                      "bundled": true,
+                      "requires": {
+                        "safe-buffer": "5.1.1"
+                      }
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "bundled": true
+                    }
+                  }
+                },
+                "uid-number": {
+                  "version": "0.0.6",
+                  "bundled": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.1",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "tweetnacl": "0.14.5"
+      },
+      "dependencies": {
+        "asn1": {
+          "version": "0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+          "dev": true
+        },
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "stat-mode": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.2.tgz",
+      "integrity": "sha1-5sgLYjEj19gM8TLOU480YokHJQI="
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
+    },
+    "stream-throttle": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+      "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+      "requires": {
+        "commander": "2.11.0",
+        "limiter": "1.1.2"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
+    },
+    "strip-ansi": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz",
+      "integrity": "sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE="
+    },
+    "superagent": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
+      "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
+      "requires": {
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "2.6.8",
+        "extend": "3.0.1",
+        "form-data": "2.2.0",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.3.4",
+        "qs": "6.4.0",
+        "readable-stream": "2.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "superagent-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/superagent-promise/-/superagent-promise-1.1.0.tgz",
+      "integrity": "sha1-uvIti73UOamwfdEPjAj1T+JQNTM="
+    },
+    "supports-color": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "dev": true,
+      "requires": {
+        "has-flag": "1.0.0"
+      }
+    },
+    "text-hex": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz",
+      "integrity": "sha1-V4+8haapJjbkLdF7QdAhjM6esrM="
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "1.0.34",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz",
+      "integrity": "sha1-rWgbaPUyGtKCfEz7G31d8s/pQu4=",
+      "dev": true
+    },
+    "tv4": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM="
+    },
+    "tv4-formats": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tv4-formats/-/tv4-formats-2.2.2.tgz",
+      "integrity": "sha1-gz2mNt7jtOd85kHRUOYIAY3GW40=",
+      "requires": {
+        "moment": "2.18.1",
+        "validator": "7.2.0"
+      },
+      "dependencies": {
+        "validator": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-7.2.0.tgz",
+          "integrity": "sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg=="
+        }
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
+      "optional": true
+    },
+    "type-detect": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+      "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.16"
+      }
+    },
+    "ua-parser-js": {
+      "version": "0.7.14",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz",
+      "integrity": "sha1-EQ1T+kw/MmwSEpK76skE0uAzh8o="
+    },
+    "ultron": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
+    },
+    "underscore": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.1.7.tgz",
+      "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA="
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+    },
+    "validator": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-8.0.0.tgz",
+      "integrity": "sha512-ni6X82obaR98FomBC8M/IF01u7d8WBjNhadxDDo+xGHGSfbTug1IS0j1zaoViYWQaMMFVfz40UhYxgs3dzvnZg=="
+    },
+    "vary": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "1.3.0"
+      },
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
+        }
+      }
+    },
+    "whatwg-fetch": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz",
+      "integrity": "sha1-DjaExsuZlbQ+/J3wPkw2XZX9nMA="
+    },
+    "which": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "requires": {
+        "isexe": "2.0.0"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "ws": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.1.0.tgz",
+      "integrity": "sha512-TU4/qKFlyQFqNITNWiqPCUY9GqlAhEotlzfcZcve6VT1YEngQl1dDMqwQQS3eMYruJ5r/UD3lcsWib6iVMDGDw==",
+      "requires": {
+        "safe-buffer": "5.1.1",
+        "ultron": "1.1.0"
+      }
+    },
+    "xml2js": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.18.tgz",
+      "integrity": "sha512-MMUtkwryoXmYoFUBT32tf7vYPHr98h6VtRLVbsjfmS5hqpp/deRMUNLZNQUHEAY4ChwyBEkisDYhH/EP15X6oA==",
+      "requires": {
+        "sax": "1.2.4",
+        "xmlbuilder": "9.0.4"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.4.tgz",
+      "integrity": "sha1-UZy0ymhtAFqEINNJbz8MruzKWA8="
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "yeast": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+      "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "z-schema": {
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.3.tgz",
+      "integrity": "sha512-0njp76Sc7C/Y1g/neUMRLoJ3dAFwlSeJSvJCBrkj6E/y5pOtLM2n7+jojGNnyAtmCRhcagNT0jpHgwpmL/ki8A==",
+      "requires": {
+        "commander": "2.11.0",
+        "lodash.get": "4.4.2",
+        "lodash.isequal": "4.5.0",
+        "validator": "8.0.0"
+      }
+    }
+  }
+}

--- a/providers/keys-filter.js
+++ b/providers/keys-filter.js
@@ -1,0 +1,64 @@
+'use strict'
+
+const Transform = require('stream').Transform
+const debug = require('debug')('signalk-server-node/providers/keys-filter')
+
+function ToSignalK(options) {
+  Transform.call(this, {
+    objectMode: true
+  })
+
+  this.exclude = options.excludeMatchingPaths
+}
+
+require('util').inherits(ToSignalK, Transform)
+
+ToSignalK.prototype._transform = function (chunk, encoding, done) {
+  // Chunck is a delta. Check options if any of the paths need to be filtered...
+  let delta = null
+  let string = false
+
+  try {
+    if (typeof chunk === 'object' && chunk !== null) {
+      delta = chunk
+    }
+    else if (typeof chunk === 'string') {
+      delta = JSON.parse(chunk)
+      string = true
+    }
+  } catch (e) {
+    debug(`Error parsing chunk: ${e.message}`)
+  }
+
+  if (Array.isArray(delta.updates)) {
+    const updates = []
+    delta.updates.forEach(update => {
+      if (Array.isArray(update.values)) {
+        const values = []
+
+        update.values.forEach(value => {
+          if (this.exclude.includes(value.path) !== true) {
+            values.push(value)
+          }
+        })
+
+        if (values.length > 0) {
+          updates.push({
+            values,
+            source: update.source,
+            timestamp: update.timestamp,
+          })
+        }
+      }
+    })
+
+    if (updates.length > 0) {
+      delta.updates = updates
+      this.push(delta)
+    }
+  }
+
+  done()
+}
+
+module.exports = ToSignalK

--- a/settings/volare-file-settings-filtered.json
+++ b/settings/volare-file-settings-filtered.json
@@ -7,11 +7,6 @@
     "uuid"  : "urn:mrn:signalk:uuid:f46d2b37-6f63-48b0-8713-8920238186ed"
   },
 
-  "excludeMatchingPaths": [
-    "navigation.courseOverGroundMagnetic",
-    "performance.velocityMadeGood"
-  ],
-
   "interfaces": {},
 
   "pipedProviders": [
@@ -54,12 +49,12 @@
          },
          {
           "type": "providers/keys-filter",
-          "optionMappings": [
-            {
-              "fromAppProperty": "config.settings.excludeMatchingPaths",
-              "toOption": "excludeMatchingPaths"
-            }
-          ]
+          "options": {
+            "excludeMatchingPaths": [
+              "navigation.courseOverGroundMagnetic",
+              "performance.velocityMadeGood"
+            ]
+          }
         }
       ]
     }

--- a/settings/volare-file-settings-filtered.json
+++ b/settings/volare-file-settings-filtered.json
@@ -1,0 +1,67 @@
+
+{
+  "vessel": {
+    "name"  : "X-Miles",
+    "brand" : "X-Yachts",
+    "type"  : "X-99",
+    "uuid"  : "urn:mrn:signalk:uuid:f46d2b37-6f63-48b0-8713-8920238186ed"
+  },
+
+  "excludeMatchingPaths": [
+    "navigation.courseOverGroundMagnetic",
+    "performance.velocityMadeGood"
+  ],
+
+  "interfaces": {},
+
+  "pipedProviders": [
+    {
+      "id": "nmeaFromFile",
+      "pipeElements": [
+         {
+           "type": "providers/filestream",
+           "options": {
+             "filename": "samples/plaka.log"
+           },
+           "optionMappings": [
+             {
+               "fromAppProperty": "argv.nmeafilename",
+               "toOption": "filename"
+             }
+           ]
+         },
+         {
+           "type": "providers/throttle",
+           "options": {
+              "rate": 500
+           }
+         },
+         {
+           "type": "providers/liner"
+         },
+         {
+            "type": "providers/nmea0183-signalk",
+            "optionMappings": [
+              {
+               "fromAppProperty": "selfId",
+               "toOption": "selfId"
+              },
+              {
+               "fromAppProperty": "selfType",
+               "toOption": "selfType"
+              }
+            ]
+         },
+         {
+          "type": "providers/keys-filter",
+          "optionMappings": [
+            {
+              "fromAppProperty": "config.settings.excludeMatchingPaths",
+              "toOption": "excludeMatchingPaths"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
I needed a way to filter out specific keys that I know are wrong (heading feature on a GPS that's not working properly). This PR implements a tiny provider that gives users that option. 

**Files added:**
- `settings/volare-file-settings-filtered.json`
- `providers/keys-filter.js`
- `bin/nmea-from-file-filtered`

**Few thoughts to contemplate:**
- Should the filter remain an array of keys or be extended to support filtering specific sources? In my use case that's not a requirement, but could be useful if there are multiple talkers on a single network that all emit the same data points. It complicates things somewhat as it couples the configuration to the format of `source` in the delta (which may be different if the source is a N2K or a NMEA0183 talker) 
- Should filters *always* be exact keys (I believe so - avoids problems with people expecting data that then isn't coming) or should we implement glob or regex patterns?