### PR TITLE
Line end fix for Isailor on Android

### DIFF
--- a/lib/interfaces/nmea-tcp.js
+++ b/lib/interfaces/nmea-tcp.js
@@ -46,7 +46,7 @@ module.exports = function(app) {
     const send = (data) => {
       _.values(openSockets).forEach(function(socket) {
         try {
-          socket.write(data + '\n');
+          socket.write(data + '\r\n');
         } catch (e) {
           console.error(e + ' ' + socket);
         }


### PR DESCRIPTION
\r\n is the correct NMEA0183 line separator. 

Detected on iSailot on Android.