### PR TITLE
Added ability to mount express apps using signalk-webapp mechanism

### DIFF
--- a/lib/interfaces/webapps.js
+++ b/lib/interfaces/webapps.js
@@ -37,7 +37,18 @@ function mountWebapps(app) {
       "../../node_modules/" + moduleData.module
     );
     debug("Mounting webapp /" + moduleData.module + ":" + webappPath);
-    app.use("/" + moduleData.module, express.static(webappPath));
+
+// could mount more here to pass control to the webapp rather than being static ?
+
+    if ( moduleData.metadata.expresshandler !== undefined ) {
+      console.log("Module has server main ", moduleData.module, moduleData.metadata.expresshandler);
+      // express hander must export a express.Router
+      var route = require(path.join(webappPath,moduleData.metadata.expresshandler));
+      app.use("/" + moduleData.module, route);
+    } else {
+      app.use("/" + moduleData.module, express.static(webappPath));
+    }
+
     app.webapps.push(moduleData.metadata);
   });
 }


### PR DESCRIPTION
This patch allows a signalk-webapp to implement an express.Route in a module identified with the metadata expresshandler and have the SignalK server load is as a route rather than as a static path. This allows the webapp to implement server side webapp code, ie additional REST APIs.

The package.json would look like 

    {
    ...
    "expresshandler": "index.js",
    "keywords": [
        "signalk-webapp"
      ],
    ....
   }


And the index.js file would look like 

    "use strict";

    var express = require('express')
    var router = express.Router()

    // middleware that is specific to this router
    router.use(function timeLog (req, res, next) {
      console.log('Time: ', Date.now())
      next()
    })
    // define the home page route
    router.get('/', function (req, res) {
      res.send('Birds home page')
    })
    // define the about route
    router.get('/about', function (req, res) {
      res.send('About birds')
    })

    module.exports = router