### PR TITLE
Ignore ssl file permissions if on win32

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -203,7 +203,13 @@ function createServer(app, cb) {
 }
 
 function hasStrictPermissions(stat) {
-  return new Mode(stat).toString() === '-r--------'
+    if (process.platform == 'win32') {
+        return new Mode(stat).toString() === '-r--r--r--'
+    }
+    else {
+        return new Mode(stat).toString() === '-r--------'
+
+    }
 }
 
 function getCertificateOptions(cb) {


### PR DESCRIPTION
This pull request replaces an earlier one (#275) made which did not properly exclude several files.

From VS2017, I first needed to 'stage' the file that needed to be included