### PR TITLE
feature: allow plugin+webapp combinations

### DIFF
--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -19,8 +19,9 @@ Plugins
 - Will not show up in the App Store until they are published on npm.
 - need usually configuration data delivered via a standard configuration UI
 - can be enabled / disable via configuration UI
+- can be a webapp as well: `/public/` directory is mounted under server's root under module id http://yourserver/moduleid
 
-In essence a plugin is an npm module with `signalk-node-server-plugin` keyword in the `package.json`. They are installed either from the server app store http:localhost:3000/appstore or from the command line with `npm install`.
+In essence a plugin is an npm module with `signalk-node-server-plugin` keyword in the `package.json`. They are installed either from the server app store http:localhost:3000/appstore or from the command line with `npm install`. With the additional "signalk-webapp" keyword it is also listed and installable as a webapp with static resources.
 
 The module must export a single `function(app)` that must return an object with functions `start(configuration)` and `stop` and a field `schema`. The schema value should be the structure of the plugin's configuration data as [JSON Schema](http://json-schema.org/).
 

--- a/lib/interfaces/webapps.js
+++ b/lib/interfaces/webapps.js
@@ -32,10 +32,13 @@ module.exports = function(app) {
 function mountWebapps(app) {
   debug("MountWebApps");
   modulesWithKeyword("signalk-webapp").forEach(moduleData => {
-    const webappPath = path.join(
+    let webappPath = path.join(
       __dirname,
       "../../node_modules/" + moduleData.module
     );
+    if (fs.existsSync(webappPath + '/public/')) {
+      webappPath += '/public/'
+    }
     debug("Mounting webapp /" + moduleData.module + ":" + webappPath);
     app.use("/" + moduleData.module, express.static(webappPath));
     app.webapps.push(moduleData.metadata);


### PR DESCRIPTION
Allow a plugin to be a webapp as well without publishing the whole
plugin module directory as static resources. Instead mount /public/
directory, if one exists.