### PR TITLE
feature: add StreamBundle.getSelfBus()

### DIFF
--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -20,6 +20,7 @@ const _ = require("lodash");
 function StreamBundle(selfId) {
   this.selfContext = "vessels." + selfId;
   this.buses = {};
+  this.selfBuses = {};
   this.streams = {};
   this.keys = new Bacon.Bus();
 }
@@ -59,6 +60,7 @@ StreamBundle.prototype.push = function(pathValueWithSourceAndContext) {
     pathValueWithSourceAndContext
   );
   if (pathValueWithSourceAndContext.context === this.selfContext) {
+    this.getSelfBus(pathValueWithSourceAndContext.path).push(pathValueWithSourceAndContext)
     this.getSelfStream(pathValueWithSourceAndContext.path).push(
       pathValueWithSourceAndContext.value
     );
@@ -78,6 +80,14 @@ StreamBundle.prototype.getSelfStream = function(path) {
   var result = this.streams[path];
   if (!result) {
     result = this.streams[path] = new Bacon.Bus();
+  }
+  return result;
+};
+
+StreamBundle.prototype.getSelfBus = function(path) {
+  var result = this.selfBuses[path];
+  if (!result) {
+    result = this.selfBuses[path] = new Bacon.Bus();
   }
   return result;
 };


### PR DESCRIPTION
Add a way to subscribe by path to updates that contain not only
the value available from getSelfStream() but also timestamp and
source information available from getBus().