### PR TITLE
feature: make meta and units retrieval work on full paths

### DIFF
--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -14,16 +14,17 @@
  * limitations under the License.
 */
 
+const debug = require('debug')('signalk-server:interfaces:rest');
+const express = require('express');
+const {getMetadata, getUnits} = require('@signalk/signalk-schema');
+
 module.exports = function(app) {
   'use strict';
 
-  var debug = require('debug')('signalk-server:interfaces:rest');
-  var express = require('express');
-
-  var pathPrefix = '/signalk';
-  var versionPrefix = '/v1';
-  var apiPathPrefix = pathPrefix + versionPrefix + '/api/';
-  var streamPath = pathPrefix + versionPrefix + '/stream';
+  const pathPrefix = '/signalk';
+  const versionPrefix = '/v1';
+  const apiPathPrefix = pathPrefix + versionPrefix + '/api/';
+  const streamPath = pathPrefix + versionPrefix + '/stream';
 
   return {
     start: function() {
@@ -39,6 +40,21 @@ module.exports = function(app) {
         }
 
         path = path.length > 0 ? path.replace(/\/$/, '').replace(/self/, app.selfId).split('/') : [];
+
+        if (path.length > 4 && path[path.length-1] === 'meta' && path[0] === 'vessels') {
+          const meta = getMetadata(path.slice(0,path.length-1).join('.'))
+          if (meta) {
+            res.json(meta)
+            return
+          }
+        }
+        if (path.length > 5 && path[path.length-1] === 'units' && path[path.length-2] === 'meta' && path[0] === 'vessels') {
+          const units = getUnits(path.slice(0,path.length-2).join('.'))
+          if (units) {
+            res.json(units)
+            return
+          }
+        }
 
         for(var i in path) {
           var p = path[i];

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,0 +1,70 @@
+const _ = require('lodash')
+const assert = require('assert')
+const freeport = require('freeport-promise')
+const WebSocket = require('ws')
+const rp = require('request-promise')
+
+describe('Metadata retrieval', () => {
+  var serverP, port
+
+  before(() => {
+    serverP = freeport().then(p => {
+      port = p
+      return startServerP(p)
+    })
+  })
+
+  it('valid .../meta works', () => {
+    return getUrl(
+      `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrue/meta`
+    ).then(result => {
+      assert.equal(result.units, 'rad')
+    })
+  })
+
+  it('invalid .../meta returns error', done => {
+    getUrl(
+      `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrueTRUE/meta`
+    ).catch(reason => {
+      assert.equal(reason.statusCode, 404)
+      done()
+    })
+  })
+
+  it('valid .../units works', () => {
+    return getUrl(
+      `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrue/meta/units`
+    ).then(result => {
+      assert.equal(result, 'rad')
+    })
+  })
+
+  it('invalid .../units returns error', done => {
+    getUrl(
+      `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrueTRUE/meta/units`
+    ).catch(reason => {
+      assert.equal(reason.statusCode, 404)
+      done()
+    })
+  })
+
+
+  function getUrl (url) {
+    return serverP.then(_ => {
+      return rp({
+        url: url,
+        method: 'GET',
+        json: true
+      })
+    })
+  }
+})
+
+function startServerP (port) {
+  const Server = require('../lib')
+  const server = new Server({
+    settings: './test/server-test-settings.json',
+    port: port
+  })
+  return server.start()
+}


### PR DESCRIPTION
With this PR the server can return schema-based metadata for all valid paths ending in `..../meta` and `.../meta/units`, which allows clients to retrieve metadata, including units, description and enum values for all paths, not just paths that the server happens to have data for.

http://localhost:3000/signalk/v1/api/vessels/foo/navigation/headingTrue/meta
```
{
units: "rad",
description: "The current true heading of the vessel"
}
```


http://localhost:3000/signalk/v1/api/vessels/foo/navigation/headingTrue/meta/units
```
"rad"
```