### PR TITLE
More robust mbtiles validation.

### DIFF
--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -99,8 +99,8 @@ function loadCharts(app, req) {
     .readdirAsync(chartBaseDir)
     .then(files => {
       return Promise.props(
-        files.reduce((result, file) => {
-          result[file] = fs
+        files.reduce((acc, file) => {
+          acc[file] = fs
             .statAsync(path.join(chartBaseDir, file))
             .then(stat => {
               if (stat.isDirectory()) {
@@ -113,7 +113,7 @@ function loadCharts(app, req) {
               console.error(err + " " + file);
               return undefined;
             });
-          return result;
+          return acc;
         }, {})
       );
     })

--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -153,6 +153,7 @@ function directoryToMapInfo(dir) {
 }
 
 function fileToMapInfo(file) {
+  debug(chartBaseDir +" " + file)
   return new Promise((resolve, reject) => {
     new MBTiles(path.join(chartBaseDir, file), (err, mbtiles) => {
       if (err) {
@@ -164,14 +165,14 @@ function fileToMapInfo(file) {
           reject(err);
           return;
         }
-        if (_.isUndefined(mbtilesData) || _.isUndefined(mbtilesData.name)) {
+        if (_.isUndefined(mbtilesData) || _.isUndefined(mbtilesData.bounds)) {
           resolve(undefined);
           return;
         }
         chartProviders[file] = mbtiles;
         resolve({
           identifier: file,
-          name: mbtilesData.name,
+          name: mbtilesData.name || mbtilesData.id,
           description: mbtilesData.description,
           bounds: mbtilesData.bounds,
           minzoom: mbtilesData.minzoom,


### PR DESCRIPTION
If you construct mbtiles from a file system images pyramid
it may be missing name, so check instead something meaningful like
bounds to check if the file is actually a valid mbtiles file.
Fixes #300.