### PR TITLE
[WIP] feature: store plugins outside of the server so that they retained

### DIFF
--- a/lib/interfaces/appstore.js
+++ b/lib/interfaces/appstore.js
@@ -14,130 +14,148 @@
  * limitations under the License.
 */
 
-const debug = require("debug")("signalk:interfaces:appstore");
-const _ = require("lodash");
-const fs = require("fs");
-const compareVersions = require("compare-versions");
-const path = require("path");
-const installModule = require("../modules").installModule;
-const findModulesWithKeyword = require("../modules").findModulesWithKeyword;
-const page = require("../page");
+const debug = require('debug')('signalk:interfaces:appstore')
+const _ = require('lodash')
+const fs = require('fs')
+const compareVersions = require('compare-versions')
+const path = require('path')
+const installModule = require('../modules').installModule
+const findModulesWithKeyword = require('../modules').findModulesWithKeyword
+const page = require('../page')
 
-module.exports = function(app) {
-  var moduleInstalling = undefined;
-  var modulesInstalledSinceStartup = {};
-  var moduleInstallQueue = [];
+module.exports = function (app) {
+  var moduleInstalling = undefined
+  var modulesInstalledSinceStartup = {}
+  var moduleInstallQueue = []
 
   return {
-    start: function() {
-      app.get("/appstore/output/:id/:version", (req, res, next) => {
-        let { result, footer } = page(__dirname + "/appstore.html");
+    start: function () {
+      app.get('/appstore/output/:id/:version', (req, res, next) => {
+        let { result, footer } = page(__dirname + '/appstore.html')
 
-        result += "<h2>Errors installing " + req.params.id + "</h2>";
-        result += "<pre>";
-        result += modulesInstalledSinceStartup[req.params.id].output;
-        result += "</pre>";
+        result += '<h2>Errors installing ' + req.params.id + '</h2>'
+        result += '<pre>'
+        result += modulesInstalledSinceStartup[req.params.id].output
+        result += '</pre>'
         result +=
           '<a href="/appstore/install/' +
           req.params.id +
-          "/" +
+          '/' +
           req.params.version +
-          '"><button type="button" class="btn">Retry</button></a> ';
-        result += footer;
-        res.send(result);
-      });
+          '"><button type="button" class="btn">Retry</button></a> '
+        result += footer
+        res.send(result)
+      })
 
-      app.get(["/appstore/install/:name/:version", "/appstore/install/:org/:name/:version"], (req, res, next) => {
-        var name = req.params.name;
-        var version = req.params.version;
+      app.get(
+        [
+          '/appstore/install/:name/:version',
+          '/appstore/install/:org/:name/:version'
+        ],
+        (req, res, next) => {
+          var name = req.params.name
+          var version = req.params.version
 
-        if ( req.params.org ) {
-          name = req.params.org + '/' + name
-        }
+          if (req.params.org) {
+            name = req.params.org + '/' + name
+          }
 
-        findPluginsAndWebapps()
-          .then(([plugins, webapps]) => {
-            if (
-              !plugins.find(packageNameIs(name)) &&
-              !webapps.find(packageNameIs(name))
-            ) {
-              res.send("No such webapp or plugin available:" + name);
-            } else {
-              if (moduleInstalling) {
-                moduleInstallQueue.push({ name: name, version: version });
+          findPluginsAndWebapps()
+            .then(([plugins, webapps]) => {
+              if (
+                !plugins.find(packageNameIs(name)) &&
+                !webapps.find(packageNameIs(name))
+              ) {
+                res.send('No such webapp or plugin available:' + name)
               } else {
-                installSKModule(name, version);
+                if (moduleInstalling) {
+                  moduleInstallQueue.push({ name: name, version: version })
+                } else {
+                  installSKModule(name, version)
+                }
+                res.redirect('/appstore')
               }
-              res.redirect("/appstore");
-            }
-          })
-          .catch(error => {
-            console.error(error.message);
-            console.error(error.stack);
-            res.status(500);
-            res.send("<pre>" + error.message + "</pre>");
-          });
-      });
+            })
+            .catch(error => {
+              console.error(error.message)
+              console.error(error.stack)
+              res.status(500)
+              res.send('<pre>' + error.message + '</pre>')
+            })
+        }
+      )
 
-      app.get("/appstore/", (req, res, next) => {
-        let { result, footer } = page(__dirname + "/appstore.html");
+      app.get('/appstore/', (req, res, next) => {
+        let { result, footer } = page(__dirname + '/appstore.html')
 
         findPluginsAndWebapps()
           .then(([plugins, webapps]) => {
             if (Object.keys(modulesInstalledSinceStartup).length) {
-              result +=
-                '<p class="text-warning">Server ';
-              if ( (moduleInstallQueue.length > 0 || moduleInstalling) || !app.securityStrategy ) {
-                result += 'restart';
+              result += '<p class="text-warning">Server '
+              if (
+                moduleInstallQueue.length > 0 ||
+                moduleInstalling ||
+                !app.securityStrategy
+              ) {
+                result += 'restart'
               } else {
-                result += '<a href="/restart">restart</a>';
+                result += '<a href="/restart">restart</a>'
               }
-              result += ' is required to finish install or update of plugins and web apps.</p>\n';
+              result +=
+                ' is required to finish install or update of plugins and web apps.</p>\n'
             }
 
-            result += makeSection("Plugins", plugins, getPlugin, "/plugins/configure/#") ;
-            result += makeSection("Web Apps", webapps, getWebApp, "");
+            result += makeSection(
+              'Plugins',
+              plugins,
+              getPlugin,
+              '/plugins/configure/#'
+            )
+            result += makeSection('Web Apps', webapps, getWebApp, '')
 
             if (moduleInstalling) {
               result +=
-                "<script>setTimeout(function(){ window.location.reload(1);}, 2000)</script>";
+                '<script>setTimeout(function(){ window.location.reload(1);}, 2000)</script>'
             }
 
-            result += footer;
-            res.send(result);
+            result += footer
+            res.send(result)
           })
           .catch(error => {
-            console.error(error.message);
-            console.error(error.stack);
-            res.status(500);
-            res.send("<pre>" + error.message + "</pre>");
-          });
-      });
+            console.error(error.message)
+            console.error(error.stack)
+            res.status(500)
+            res.send('<pre>' + error.message + '</pre>')
+          })
+      })
     },
-    stop: function() {}
-  };
+    stop: function () {}
+  }
 
-  function findPluginsAndWebapps() {
+  function findPluginsAndWebapps () {
     return Promise.all([
-      findModulesWithKeyword("signalk-node-server-plugin"),
-      findModulesWithKeyword("signalk-webapp")
-    ]);
+      findModulesWithKeyword('signalk-node-server-plugin'),
+      findModulesWithKeyword('signalk-webapp')
+    ])
   }
 
-  function getPlugin(id) {
-    return app.plugins.find(plugin => plugin.packageName === id);
+  function getPlugin (id) {
+    return app.plugins.find(plugin => plugin.packageName === id)
   }
 
-  function getWebApp(id) {
-    return app.webapps.find(webapp => webapp.name === id);
+  function getWebApp (id) {
+    return app.webapps.find(webapp => webapp.name === id)
   }
 
-  function makeSection(title, modules, existing, pathPrefix) {
+  function makeSection (title, modules, existing, pathPrefix) {
     modules = modules.sort((left, right) => {
-      if ( pathPrefix+left.package.name < pathPrefix+right.package.name ) {
-        return -1;
-      } else if ( pathPrefix+left.package.name > pathPrefix+right.package.name ) {
-        return 1;
+      if (pathPrefix + left.package.name < pathPrefix + right.package.name) {
+        return -1
+      } else if (
+        pathPrefix + left.package.name >
+        pathPrefix + right.package.name
+      ) {
+        return 1
       } else {
         return 0
       }
@@ -155,21 +173,21 @@ module.exports = function(app) {
       </tr>
       ${makeRows(modules, existing, pathPrefix)}
     </table>
-    `;
+    `
   }
 
-  function makeRows(modules, existing, pathPrefix) {
-    return modules.reduce(function(result, moduleInfo) {
-      var name = moduleInfo.package.name;
-      var version = moduleInfo.package.version;
+  function makeRows (modules, existing, pathPrefix) {
+    return modules.reduce(function (result, moduleInfo) {
+      var name = moduleInfo.package.name
+      var version = moduleInfo.package.version
 
-      var installedModule = existing(name);
-      var isLink = false;
+      var installedModule = existing(name)
+      var isLink = false
       if (installedModule) {
-        var stat = fs.lstatSync(
-          path.join(__dirname, "../../node_modules/" + name)
-        );
-        var isLink = stat.isSymbolicLink();
+        var mpath = path.join(__dirname, '../../node_modules/' + name)
+        if (!fs.existsSync(mpath)) { mpath = path.join(app.config.configPath, 'node_modules', name) }
+        var stat = fs.lstatSync(mpath)
+        var isLink = stat.isSymbolicLink()
       }
 
       result += `
@@ -181,119 +199,126 @@ module.exports = function(app) {
           <td>${getAuthorColumn(moduleInfo)}</td>
           <td>${getNpmColumn(moduleInfo)}</td>
         </tr>
-      `;
-      return result;
-    }, "");
+      `
+      return result
+    }, '')
   }
 
-  function getNameColumn(name, installedModule, pathPrefix) {
-    return installedModule ? `<a href="${pathPrefix}${name}">${name}</a>`: `${name}`
+  function getNameColumn (name, installedModule, pathPrefix) {
+    return installedModule
+      ? `<a href="${pathPrefix}${name}">${name}</a>`
+      : `${name}`
   }
 
-  function getAuthorColumn(moduleInfo) {
-    debug(moduleInfo.package.name + " author: " + moduleInfo.package.author)
+  function getAuthorColumn (moduleInfo) {
+    debug(moduleInfo.package.name + ' author: ' + moduleInfo.package.author)
     return (
-      (moduleInfo.package.author && (moduleInfo.package.author.name || moduleInfo.package.author.email)) +
-      "<i>" +
+      (moduleInfo.package.author &&
+        (moduleInfo.package.author.name || moduleInfo.package.author.email)) +
+      '<i>' +
       (moduleInfo.package.contributors || [])
         .map(contributor => contributor.name || contributor.email)
-        .join(",") +
-      "</i>" +
-      (moduleInfo.package.name.startsWith("@signalk/")
-        ? " (Signal K team)"
-        : "")
-    );
+        .join(',') +
+      '</i>' +
+      (moduleInfo.package.name.startsWith('@signalk/')
+        ? ' (Signal K team)'
+        : '')
+    )
   }
 
-  function getNpmColumn(moduleInfo) {
-    const npm = _.get(moduleInfo.package, "links.npm");
-    return npm ? '<a href="' + npm + '">npm</a>' : "";
+  function getNpmColumn (moduleInfo) {
+    const npm = _.get(moduleInfo.package, 'links.npm')
+    return npm ? '<a href="' + npm + '">npm</a>' : ''
   }
 
-  function getInstallColumn(name, version, installedModule, isLink) {
-    let result = "";
+  function getInstallColumn (name, version, installedModule, isLink) {
+    let result = ''
     if (modulesInstalledSinceStartup[name]) {
       if (moduleInstalling && moduleInstalling.name == name) {
-        result += `<p class="text-primary">Installing ${moduleInstalling.version}...</p>`;
+        result += `<p class="text-primary">Installing ${moduleInstalling.version}...</p>`
       } else if (modulesInstalledSinceStartup[name].code == 0) {
-        result += `<p class="text-success"> Installed ${modulesInstalledSinceStartup[name].version}</p>`;
+        result += `<p class="text-success"> Installed ${modulesInstalledSinceStartup[
+          name
+        ].version}</p>`
       } else {
         result += `
-          <a href="/appstore/output/${name}/${modulesInstalledSinceStartup[name].version}">
+          <a href="/appstore/output/${name}/${modulesInstalledSinceStartup[name]
+  .version}">
           <button type="button" class="btn-danger">Error</button>
-          </a>`;
+          </a>`
       }
     } else if (moduleInstallQueue.find(p => p.name == name)) {
-      result += '<p class="text-primary">Waiting...</p>';
+      result += '<p class="text-primary">Waiting...</p>'
     } else if (!installedModule) {
-      result += `<a href="/appstore/install/${name}/${version}"><button type="button" class="btn">Install ${version}</button></a>`;
+      result += `<a href="/appstore/install/${name}/${version}"><button type="button" class="btn">Install ${version}</button></a>`
     } else {
-      result += `${installedModule.version} Installed`;
+      result += `${installedModule.version} Installed`
       if (isLink) {
-        result += '<p class="text-danger">(Linked)' + "</p>";
+        result += '<p class="text-danger">(Linked)' + '</p>'
       }
     }
-    return result;
+    return result
   }
 
-  function getUpdateColumn(name, version, installedModule, isLink) {
-    let result = "";
+  function getUpdateColumn (name, version, installedModule, isLink) {
+    let result = ''
     if (!modulesInstalledSinceStartup[name]) {
       if (installedModule) {
-        var compared = compareVersions(version, installedModule.version);
+        var compared = compareVersions(version, installedModule.version)
         if (compared > 0) {
           if (!isLink) {
             result += `
             <a href="/appstore/install/${name}/${version}">
             <button type="button" class="btn">Update to ${version}</button>
-            </a>`;
+            </a>`
           } else {
-            result += version;
+            result += version
           }
         } else if (compared < 0) {
-          result += "Newer Installed";
+          result += 'Newer Installed'
         } else {
-          result += "Latest Installed";
+          result += 'Latest Installed'
         }
       }
     }
-    return result;
+    return result
   }
 
-  function installSKModule(module, version) {
+  function installSKModule (module, version) {
     moduleInstalling = {
       name: module,
       output: [],
       version: version
-    };
-    modulesInstalledSinceStartup[module] = moduleInstalling;
+    }
+    modulesInstalledSinceStartup[module] = moduleInstalling
 
     installModule(
+      app,
       module,
       version,
       output => {
-        modulesInstalledSinceStartup[module].output.push(output);
-        console.log(`stdout: ${output}`);
+        modulesInstalledSinceStartup[module].output.push(output)
+        console.log(`stdout: ${output}`)
       },
       output => {
-        modulesInstalledSinceStartup[module].output.push(output);
-        console.error(`stderr: ${output}`);
+        modulesInstalledSinceStartup[module].output.push(output)
+        console.error(`stderr: ${output}`)
       },
       code => {
-        debug("close: " + module);
-        modulesInstalledSinceStartup[module]["code"] = code;
-        moduleInstalling = undefined;
-        console.log(`child process exited with code ${code}`);
+        debug('close: ' + module)
+        modulesInstalledSinceStartup[module]['code'] = code
+        moduleInstalling = undefined
+        console.log(`child process exited with code ${code}`)
 
         if (moduleInstallQueue.length) {
-          var next = moduleInstallQueue.splice(0, 1)[0];
-          installSKModule(next.name, next.version);
+          var next = moduleInstallQueue.splice(0, 1)[0]
+          installSKModule(next.name, next.version)
         }
       }
-    );
+    )
   }
-};
+}
 
-function packageNameIs(name) {
-  return x => x.package.name === name;
+function packageNameIs (name) {
+  return x => x.package.name === name
 }

--- a/lib/interfaces/appstore.js
+++ b/lib/interfaces/appstore.js
@@ -184,8 +184,15 @@ module.exports = function (app) {
       var installedModule = existing(name)
       var isLink = false
       if (installedModule) {
-        var mpath = path.join(__dirname, '../../node_modules/' + name)
-        if (!fs.existsSync(mpath)) { mpath = path.join(app.config.configPath, 'node_modules', name) }
+        var mpath = path.join(
+          app.config.configPath,
+          'plugin-config-data',
+          'node_modules',
+          name
+        )
+        if (!fs.existsSync(mpath)) {
+          mpath = path.join(__dirname, '../../node_modules/' + name)
+        }
         var stat = fs.lstatSync(mpath)
         var isLink = stat.isSymbolicLink()
       }

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -19,36 +19,56 @@ var fs = require('fs')
 var path = require('path')
 var express = require('express')
 var _ = require('lodash')
-const modulesWithKeyword = require("../modules").modulesWithKeyword;
+const modulesWithKeyword = require('../modules').modulesWithKeyword
 
+const packageJson = `{
+  "name": "node-server-plugins",
+  "version": "0.0.1",
+  "description": "Node Server Plugins",
+  "dependencies": {
+  }
+}`
 
-module.exports = function(app) {
-
+module.exports = function (app) {
   return {
-    start: function() {
+    start: function () {
       startPlugins(app)
 
-      ensureExists(path.join(app.config.configPath, "plugin-config-data"));
+      var configDataPath = path.join(
+        app.config.configPath,
+        'plugin-config-data'
+      )
+      ensureExists(configDataPath)
+      ensurePackageJsonExists(configDataPath)
 
-      app.use('/plugins/configure', express.static(path.join(__dirname, '/../../plugin-config/public')));
+      app.use(
+        '/plugins/configure',
+        express.static(path.join(__dirname, '/../../plugin-config/public'))
+      )
 
-      router = express.Router();
+      router = express.Router()
 
-      app.get('/plugins', function(req, res, next) {
+      app.get('/plugins', function (req, res, next) {
         res.json(
           _.sortBy(app.plugins, [
             plugin => {
               return plugin.name
             }
-          ]).map((plugin) => {
+          ]).map(plugin => {
             var data = null
             try {
               data = getPluginOptions(plugin.id)
-            } catch(e) {
-              console.log(e.code + " " + e.path)
+            } catch (e) {
+              console.log(e.code + ' ' + e.path)
             }
-            var schema = typeof plugin.schema === 'function' ? plugin.schema() : plugin.schema
-            var uiSchema = typeof plugin.uiSchema === 'function' ? plugin.uiSchema() : plugin.uiSchema
+            var schema =
+              typeof plugin.schema === 'function'
+                ? plugin.schema()
+                : plugin.schema
+            var uiSchema =
+              typeof plugin.uiSchema === 'function'
+                ? plugin.uiSchema()
+                : plugin.uiSchema
             return {
               id: plugin.id,
               name: plugin.name,
@@ -59,116 +79,131 @@ module.exports = function(app) {
               state: plugin.state,
               data: data
             }
-          }))
-      });
+          })
+        )
+      })
     }
   }
 
-function ensureExists(dir) {
-  if(!fs.existsSync(dir)) {
-    fs.mkdirSync(dir);
+  function ensureExists (dir) {
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir)
+    }
   }
-}
 
-function pathForPluginId(id) {
-  return path.join(app.config.configPath, "plugin-config-data", id + '.json')
-}
+  function ensurePackageJsonExists (dir) {
+    var pkg = path.join(dir, 'package.json')
+    if (!fs.existsSync(pkg)) {
+      fs.writeFileSync(pkg, packageJson)
+    }
+  }
 
-function savePluginOptions(pluginId, data, callback) {
-  const config = JSON.parse(JSON.stringify(data))
-  fs.writeFile(pathForPluginId(pluginId), JSON.stringify(data, null, 2), callback);
-}
+  function pathForPluginId (id) {
+    return path.join(app.config.configPath, 'plugin-config-data', id + '.json')
+  }
 
+  function savePluginOptions (pluginId, data, callback) {
+    const config = JSON.parse(JSON.stringify(data))
+    fs.writeFile(
+      pathForPluginId(pluginId),
+      JSON.stringify(data, null, 2),
+      callback
+    )
+  }
 
-function getPluginOptions(id) {
-  try {
-    const optionsAsString = fs.readFileSync(pathForPluginId(id), 'utf8');
+  function getPluginOptions (id) {
     try {
-      const options = JSON.parse(optionsAsString)
-      if(process.env.DISABLEPLUGINS) {
-        debug("Plugins disabled by configuration")
-        options.enabled = false
+      const optionsAsString = fs.readFileSync(pathForPluginId(id), 'utf8')
+      try {
+        const options = JSON.parse(optionsAsString)
+        if (process.env.DISABLEPLUGINS) {
+          debug('Plugins disabled by configuration')
+          options.enabled = false
+        }
+        debug(optionsAsString)
+        return options
+      } catch (e) {
+        console.error('Could not parse JSON options:' + optionsAsString)
+        return {}
       }
-      debug(optionsAsString)
-      return options
-    } catch(e) {
-      console.error("Could not parse JSON options:" + optionsAsString);
+    } catch (e) {
+      debug(
+        'Could not find options for plugin ' + id + ', returning empty options'
+      )
       return {}
     }
-  } catch(e) {
-    debug("Could not find options for plugin " + id + ", returning empty options")
-    return {}
   }
-}
 
-function startPlugins(app) {
-  app.plugins = []
-  modulesWithKeyword('signalk-node-server-plugin').forEach(moduleData => {
-    registerPlugin(app, moduleData.module, moduleData.metadata)
-  })
-}
-
-function registerPlugin(app, pluginName, metadata) {
-  debug('Registering plugin ' + pluginName)
-  const plugin = require(pluginName)(app)
-  const options = getPluginOptions(plugin.id)
-  const restart = (newConfiguration) => {
-    const pluginOptions = getPluginOptions(plugin.id)
-    pluginOptions.configuration = newConfiguration
-    savePluginOptions(plugin.id, pluginOptions, (err) => {
-      if(err) {
-        console.error(err)
-      } else {
-        plugin.stop()
-        plugin.start(newConfiguration, restart)
-      }
+  function startPlugins (app) {
+    app.plugins = []
+    modulesWithKeyword(
+      app,
+      'signalk-node-server-plugin'
+    ).forEach(moduleData => {
+      registerPlugin(app, moduleData.module, moduleData.metadata)
     })
   }
-  if(options && options.enabled) {
-    debug('Starting plugin ' + pluginName)
-    plugin.start(getPluginOptions(plugin.id).configuration, restart)
-  }
-  app.plugins.push(plugin)
 
-  plugin.version = metadata.version
-  plugin.packageName = metadata.name
-
-  var router = express.Router()
-  router.get("/", (req, res) => {
+  function registerPlugin (app, pluginName, metadata) {
+    debug('Registering plugin ' + pluginName)
+    const plugin = require(pluginName)(app)
     const options = getPluginOptions(plugin.id)
-    res.json({
-      enabled: options.enabled,
-      id: plugin.id,
-      name: plugin.name,
-      version: plugin.version
-    })
-  })
+    const restart = newConfiguration => {
+      const pluginOptions = getPluginOptions(plugin.id)
+      pluginOptions.configuration = newConfiguration
+      savePluginOptions(plugin.id, pluginOptions, err => {
+        if (err) {
+          console.error(err)
+        } else {
+          plugin.stop()
+          plugin.start(newConfiguration, restart)
+        }
+      })
+    }
+    if (options && options.enabled) {
+      debug('Starting plugin ' + pluginName)
+      plugin.start(getPluginOptions(plugin.id).configuration, restart)
+    }
+    app.plugins.push(plugin)
 
-  router.post("/config", (req, res) => {
-    savePluginOptions(plugin.id, req.body, (err) => {
-      if(err) {
-        console.log(err)
-        res.status(500)
-        res.send(err)
-        return
-      }
-      res.send("Saved configuration for plugin " + plugin.id)
-      plugin.stop()
+    plugin.version = metadata.version
+    plugin.packageName = metadata.name
+
+    var router = express.Router()
+    router.get('/', (req, res) => {
       const options = getPluginOptions(plugin.id)
-      if(options.enabled) {
-        plugin.start(options.configuration, restart)
-      }
+      res.json({
+        enabled: options.enabled,
+        id: plugin.id,
+        name: plugin.name,
+        version: plugin.version
+      })
     })
-  })
 
-  if(typeof plugin.registerWithRouter != 'undefined') {
-    plugin.registerWithRouter(router)
-  }
-  app.use("/plugins/" + plugin.id, router)
+    router.post('/config', (req, res) => {
+      savePluginOptions(plugin.id, req.body, err => {
+        if (err) {
+          console.log(err)
+          res.status(500)
+          res.send(err)
+          return
+        }
+        res.send('Saved configuration for plugin ' + plugin.id)
+        plugin.stop()
+        const options = getPluginOptions(plugin.id)
+        if (options.enabled) {
+          plugin.start(options.configuration, restart)
+        }
+      })
+    })
 
-  if(typeof plugin.signalKApiRoutes === 'function') {
-    app.use("/signalk/v1/api", plugin.signalKApiRoutes(express.Router()))
+    if (typeof plugin.registerWithRouter !== 'undefined') {
+      plugin.registerWithRouter(router)
+    }
+    app.use('/plugins/' + plugin.id, router)
+
+    if (typeof plugin.signalKApiRoutes === 'function') {
+      app.use('/signalk/v1/api', plugin.signalKApiRoutes(express.Router()))
+    }
   }
 }
-};
-

--- a/lib/interfaces/webapps.js
+++ b/lib/interfaces/webapps.js
@@ -14,33 +14,33 @@
  * limitations under the License.
 */
 
-var debug = require("debug")("signalk:interfaces:webapps");
-var fs = require("fs");
-var path = require("path");
-var express = require("express");
-const modulesWithKeyword = require("../modules").modulesWithKeyword;
+var debug = require('debug')('signalk:interfaces:webapps')
+var fs = require('fs')
+var path = require('path')
+var express = require('express')
+const modulesWithKeyword = require('../modules').modulesWithKeyword
 
-module.exports = function(app) {
+module.exports = function (app) {
   return {
-    start: function() {
-      mountWebapps(app);
+    start: function () {
+      mountWebapps(app)
     },
-    stop: function() {}
-  };
-};
+    stop: function () {}
+  }
+}
 
-function mountWebapps(app) {
-  debug("MountWebApps");
-  modulesWithKeyword("signalk-webapp").forEach(moduleData => {
+function mountWebapps (app) {
+  debug('MountWebApps')
+  modulesWithKeyword(app, 'signalk-webapp').forEach(moduleData => {
     let webappPath = path.join(
       __dirname,
-      "../../node_modules/" + moduleData.module
-    );
+      '../../node_modules/' + moduleData.module
+    )
     if (fs.existsSync(webappPath + '/public/')) {
       webappPath += '/public/'
     }
-    debug("Mounting webapp /" + moduleData.module + ":" + webappPath);
-    app.use("/" + moduleData.module, express.static(webappPath));
-    app.webapps.push(moduleData.metadata);
-  });
+    debug('Mounting webapp /' + moduleData.module + ':' + webappPath)
+    app.use('/' + moduleData.module, express.static(webappPath))
+    app.webapps.push(moduleData.metadata)
+  })
 }

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -25,14 +25,16 @@ function modulesWithKeyword (app, keyword) {
   var pluginsPath = path.join(
     app.config.configPath,
     'plugin-config-data',
-    'node_modules/'
+    'node_modules'
   )
   if (fs.existsSync(pluginsPath)) {
     res = findModulesInDir(pluginsPath, keyword)
   }
 
-  var local = findModulesInDir('./node_modules/', keyword)
-  res.push.apply(res, local)
+  res.push.apply(
+    res,
+    findModulesInDir(path.join(process.cwd(), 'node_modules'), keyword)
+  )
 
   return res
 }
@@ -44,20 +46,18 @@ function findModulesInDir (dir, keyword) {
     .reduce((result, filename) => {
       if (filename.indexOf('@') === 0) {
         return result.concat(
-          findModulesInDir(dir + filename + '/', keyword).map(entry => {
-            var prefix = dir[0] != '/' ? filename + '/' : ''
+          findModulesInDir(path.join(dir, filename), keyword).map(entry => {
             return {
-              module: prefix + entry.module,
+              module: entry.module,
               metadata: entry.metadata
             }
           })
         )
       } else {
         let metadata
-        var require_loc = dir[0] == '/' ? '' : '../'
 
         try {
-          metadata = require(require_loc + dir + filename + '/package.json')
+          metadata = require(path.join(dir, filename, 'package.json'))
         } catch (err) {
           console.log(err)
         }
@@ -66,8 +66,7 @@ function findModulesInDir (dir, keyword) {
           metadata.keywords &&
           metadata.keywords.includes(keyword)
         ) {
-          var prefix = dir[0] != '/' ? '' : require_loc + dir
-          result.push({ module: prefix + filename, metadata: metadata })
+          result.push({ module: path.join(dir, filename), metadata: metadata })
         }
       }
       return result

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -18,9 +18,23 @@ const fs = require('fs')
 const spawn = require('child_process').spawn
 const debug = require('debug')('signalk:modules')
 const agent = require('superagent-promise')(require('superagent'), Promise)
+const path = require('path')
 
-function modulesWithKeyword (keyword) {
-  return findModulesInDir('./node_modules/', keyword)
+function modulesWithKeyword (app, keyword) {
+  var res = []
+  var pluginsPath = path.join(
+    app.config.configPath,
+    'plugin-config-data',
+    'node_modules/'
+  )
+  if (fs.existsSync(pluginsPath)) {
+    res = findModulesInDir(pluginsPath, keyword)
+  }
+
+  var local = findModulesInDir('./node_modules/', keyword)
+  res.push.apply(res, local)
+
+  return res
 }
 
 function findModulesInDir (dir, keyword) {
@@ -31,16 +45,19 @@ function findModulesInDir (dir, keyword) {
       if (filename.indexOf('@') === 0) {
         return result.concat(
           findModulesInDir(dir + filename + '/', keyword).map(entry => {
+            var prefix = dir[0] != '/' ? filename + '/' : ''
             return {
-              module: filename + '/' + entry.module,
+              module: prefix + entry.module,
               metadata: entry.metadata
             }
           })
         )
       } else {
         let metadata
+        var require_loc = dir[0] == '/' ? '' : '../'
+
         try {
-          metadata = require('../' + dir + filename + '/package.json')
+          metadata = require(require_loc + dir + filename + '/package.json')
         } catch (err) {
           console.log(err)
         }
@@ -49,19 +66,21 @@ function findModulesInDir (dir, keyword) {
           metadata.keywords &&
           metadata.keywords.includes(keyword)
         ) {
-          result.push({ module: filename, metadata: metadata })
+          var prefix = dir[0] != '/' ? '' : require_loc + dir
+          result.push({ module: prefix + filename, metadata: metadata })
         }
       }
       return result
     }, [])
 }
 
-function installModule (name, version, onData, onErr, onClose) {
+function installModule (app, name, version, onData, onErr, onClose) {
   debug('installing: ' + name + ' ' + version)
   var npm
+  var opts = { cwd: path.join(app.config.configPath, 'plugin-config-data') }
   if (process.platform == 'win32') {
-    npm = spawn('cmd', ['/c', 'npm --no-save install ' + name])
-  } else npm = spawn('npm', ['--no-save', 'install', name])
+    npm = spawn('cmd', ['/c', 'npm --save install ' + name], opts)
+  } else npm = spawn('npm', ['--save', 'install', name], opts)
 
   npm.stdout.on('data', onData)
   npm.stderr.on('data', onErr)


### PR DESCRIPTION
This addresses issue #304 

Plugins are installed to plugin-config-data/node_modules, so they are retained after removing ./node_modules.

When used in combination with the `-c` option, they are stored completely separately from the node server installation.