### PR TITLE
feature: add tls certificate chain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,9 @@ The server can also automatically discover other Signal K devices and connect to
 
 HTTPS
 -----
-You can use a self generated certificate simply by enabling SSL with `"ssl":true` in the [settings file](https://github.com/SignalK/signalk-server-node/blob/master/settings/aava-non-ssl-file-settings.json#L9). If no `ssl-key.pem` & `ssl-cert.pem` files are found under settings they will be created.
+Https is enabled by default unless you disable it with `"ssl":true` in the [settings file](https://github.com/SignalK/signalk-server-node/blob/master/settings/aava-non-ssl-file-settings.json#L9). If no `ssl-key.pem` & `ssl-cert.pem` files are found under settings they will be created. If you need to configure a certificate chain add it in `ssl-chain.pem` under settings.
+
+By default the server listens to both http and https in the same port.
 
 Logging
 -------

--- a/lib/index.js
+++ b/lib/index.js
@@ -250,15 +250,37 @@ function getCertificateOptions(cb) {
       )
       return
     }
+    let ca = undefined
+    if (fs.existsSync('./settings/ssl-chain.pem')) {
+      debug('Found ssl-chain.pem')
+      ca = getCAChainArray('./settings/ssl-chain.pem')
+      debug(JSON.stringify(ca, null, 2))
+    }
     debug('Using certificate ssl-key.pem and ssl-cert.pem in ./settings/')
     cb(null, {
       key: fs.readFileSync('./settings/ssl-key.pem'),
-      cert: fs.readFileSync('./settings/ssl-cert.pem')
+      cert: fs.readFileSync('./settings/ssl-cert.pem'),
+      ca
     })
     return
   } else {
     createCertificateOptions(cb)
   }
+}
+
+function getCAChainArray(filename) {
+  let chainCert = []
+  return fs
+    .readFileSync(filename, 'utf8')
+    .split('\n')
+    .reduce((ca, line) => {
+      chainCert.push(line)
+      if (line.match(/-END CERTIFICATE-/)) {
+        ca.push(chainCert.join('\n'))
+        chainCert = []
+      }
+      return ca
+    }, [])
 }
 
 function createCertificateOptions(cb) {


### PR DESCRIPTION
Add support for configuring a tls certificate chain.
Update README https section to reflect the current state
of affairs.