### PR TITLE
fix: fix naked property subscription handling

### DIFF
--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -30,17 +30,18 @@ StreamBundle.prototype.pushDelta = function (delta) {
     delta.updates.forEach(update => {
       if (update.values) {
         update.values.forEach(pathValue => {
-          var pathValues
-          if (pathValue.path == '') {
-            pathValues = []
-            _.keys(pathValue.value).forEach(key => {
-              pathValues.push({ path: key, value: pathValue.value[key] })
-            })
-          } else {
-            pathValues = [pathValue]
-          }
-          pathValues.forEach(pathValue => {
-            this.push({
+          var paths =
+            pathValue.path === ''
+              ? getPathsFromObjectValue(pathValue.value)
+              : [pathValue.path]
+          /*
+            For values with empty path and object value we enumerate all the paths in the object
+            and push the original delta's value to all those buses, so that subscriptionmanager
+            can track hits also for paths of naked values (no path, just object value) and when
+            regenerating the outgoing delta will use the unmodified, original delta pathvalue.
+          */
+          paths.forEach(path => {
+            this.push(path, {
               path: pathValue.path,
               value: pathValue.value,
               context: delta.context,
@@ -55,17 +56,32 @@ StreamBundle.prototype.pushDelta = function (delta) {
   }
 }
 
-StreamBundle.prototype.push = function (pathValueWithSourceAndContext) {
-  this.getBus(pathValueWithSourceAndContext.path).push(
-    pathValueWithSourceAndContext
-  )
+function getPathsFromObjectValue (objectValue) {
+  return Object.keys(objectValue).reduce((acc, propName) => {
+    const propValue = objectValue[propName]
+    if (_.isObject(propValue)) {
+      accumulatePathsFromValues(acc, propName + '.', propValue)
+    } else {
+      acc.push(propName)
+    }
+    return acc
+  }, [])
+}
+
+function accumulatePathsFromValues (acc, prefix, objectValue) {
+  Object.keys(objectValue).forEach(propName => {
+    const propValue = objectValue[propName]
+    if (_.isObject(propValue)) {
+      accumulatePathsFromValues(acc, `${prefix}.${propName}`, propValue)
+    }
+  })
+}
+
+StreamBundle.prototype.push = function (path, pathValueWithSourceAndContext) {
+  this.getBus(path).push(pathValueWithSourceAndContext)
   if (pathValueWithSourceAndContext.context === this.selfContext) {
-    this.getSelfBus(pathValueWithSourceAndContext.path).push(
-      pathValueWithSourceAndContext
-    )
-    this.getSelfStream(pathValueWithSourceAndContext.path).push(
-      pathValueWithSourceAndContext.value
-    )
+    this.getSelfBus(path).push(pathValueWithSourceAndContext)
+    this.getSelfStream(path).push(pathValueWithSourceAndContext.value)
   }
 }
 


### PR DESCRIPTION
Subscription handling is broken: inputs like `{ path: '', value: { name: 'SomeBoat' }}` produce delta that has `{"path":"name","value":"SomeBoat"}`.

SubscriptionManager handles deltas' values independently: the
values are pushed to Bacon buses, bus per path, by StreamBundle.
When the bus's subscriptions fire SM reconstructs outgoing delta
from the incoming pathvalues. Previously StreamBundle normalized
pathvalues of naked properties, where path is empty, to synthesized
pathvalues with 'normal' paths and matching values. The generated
outgoing delta was then not naked, as it was generated from the
synthesized pathvalues.
This commit changes the handling so that the original, incoming
normalised pathvalue is pushed to buses for paths generated from
the object value's structure. Since we are pushing the normalised
pathvalues from the original delta the output pathvalues match
the incoming data.