### PR TITLE
fix: mdns registration failes when running via systemd

### DIFF
--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -123,7 +123,7 @@ module.exports = function (app) {
     mdns: {
       name: app.config.settings.ssl ? '_signalk-https' : '_signalk-http',
       type: 'tcp',
-      port: ports.getPrimaryPort(app)
+      port: ports.getExternalPort(app)
     }
   }
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -32,7 +32,7 @@ module.exports = function (app) {
   api.mdns = {
     name: app.config.settings.ssl ? '_signalk-wss' : '_signalk-ws',
     type: 'tcp',
-    port: ports.getPrimaryPort(app)
+    port: ports.getExternalPort(app)
   }
 
   api.start = function () {

--- a/lib/mdns.js
+++ b/lib/mdns.js
@@ -56,7 +56,7 @@ module.exports = function mdnsResponder (app) {
   let types = []
   types.push({
     type: app.config.settings.ssl ? mdns['tcp']('https') : mdns['tcp']('http'),
-    port: ports.getPrimaryPort(app)
+    port: ports.getExternalPort(app)
   })
 
   for (var key in app.interfaces) {

--- a/lib/ports.js
+++ b/lib/ports.js
@@ -40,5 +40,14 @@ module.exports = {
     return app.config.settings.ssl
       ? Number(process.env.PORT) || app.config.settings.port || 3000
       : -7777
+  },
+
+  getExternalPort: function (app) {
+    if (process.env.EXTERNALPORT > 0) {
+      return Number(process.env.EXTERNALPORT)
+    }
+    return app.config.settings.ssl
+      ? Number(process.env.SSLPORT) || app.config.settings.sslport || 3443
+      : Number(process.env.PORT) || app.config.settings.port || 3000
   }
 }


### PR DESCRIPTION

Note that you must edit /etc/systemd/system/signalk.service and add following under `[Service]`

Environment=EXTERNALPORT=80

(replace 80 with the port you are using)