### PR TITLE
 feature: turn on security by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,8 +49,52 @@ function Server(opts) {
   require('./config/config')(app)
   app.version = '0.0.1'
 
+  app.getPluginOptionsPath = function(id) {
+    return path.join(app.config.configPath, 'plugin-config-data', id + '.json')
+  }
+
+  app.savePluginOptions = function(pluginId, data, callback) {
+    const config = JSON.parse(JSON.stringify(data))
+    const path = app.getPluginOptionsPath(pluginId)
+    const json = JSON.stringify(data, null, 2)
+
+    if (callback) {
+      fs.writeFile(path, json, callback)
+    } else {
+      fs.writeFileSync(path, json)
+    }
+  }
+
+  app.getPluginOptions = function(id) {
+    try {
+      const optionsAsString = fs.readFileSync(
+        app.getPluginOptionsPath(id),
+        'utf8'
+      )
+      try {
+        const options = JSON.parse(optionsAsString)
+        if (process.env.DISABLEPLUGINS) {
+          debug('Plugins disabled by configuration')
+          options.enabled = false
+        }
+        debug(optionsAsString)
+        return options
+      } catch (e) {
+        console.error('Could not parse JSON options:' + optionsAsString)
+        return {}
+      }
+    } catch (e) {
+      debug(
+        'Could not find options for plugin ' + id + ', returning empty options'
+      )
+      return {}
+    }
+  }
+
   if (app.config.settings.security && app.config.settings.security.strategy) {
     app.securityStrategy = require(app.config.settings.security.strategy)(app)
+  } else {
+    app.securityStrategy = require('@signalk/sk-simple-token-security')(app)
   }
 
   app.get('/', (req, res) => {

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -44,7 +44,7 @@ module.exports = function (app) {
           ]).map(plugin => {
             var data = null
             try {
-              data = getPluginOptions(plugin.id)
+              data = app.getPluginOptions(plugin.id)
             } catch (e) {
               console.log(e.code + ' ' + e.path)
             }
@@ -78,42 +78,6 @@ module.exports = function (app) {
     }
   }
 
-  function pathForPluginId (id) {
-    return path.join(app.config.configPath, 'plugin-config-data', id + '.json')
-  }
-
-  function savePluginOptions (pluginId, data, callback) {
-    const config = JSON.parse(JSON.stringify(data))
-    fs.writeFile(
-      pathForPluginId(pluginId),
-      JSON.stringify(data, null, 2),
-      callback
-    )
-  }
-
-  function getPluginOptions (id) {
-    try {
-      const optionsAsString = fs.readFileSync(pathForPluginId(id), 'utf8')
-      try {
-        const options = JSON.parse(optionsAsString)
-        if (process.env.DISABLEPLUGINS) {
-          debug('Plugins disabled by configuration')
-          options.enabled = false
-        }
-        debug(optionsAsString)
-        return options
-      } catch (e) {
-        console.error('Could not parse JSON options:' + optionsAsString)
-        return {}
-      }
-    } catch (e) {
-      debug(
-        'Could not find options for plugin ' + id + ', returning empty options'
-      )
-      return {}
-    }
-  }
-
   function startPlugins (app) {
     app.plugins = []
     modulesWithKeyword('signalk-node-server-plugin').forEach(moduleData => {
@@ -124,11 +88,11 @@ module.exports = function (app) {
   function registerPlugin (app, pluginName, metadata) {
     debug('Registering plugin ' + pluginName)
     const plugin = require(pluginName)(app)
-    const options = getPluginOptions(plugin.id)
+    const options = app.getPluginOptions(plugin.id)
     const restart = newConfiguration => {
-      const pluginOptions = getPluginOptions(plugin.id)
+      const pluginOptions = app.getPluginOptions(plugin.id)
       pluginOptions.configuration = newConfiguration
-      savePluginOptions(plugin.id, pluginOptions, err => {
+      app.savePluginOptions(plugin.id, pluginOptions, err => {
         if (err) {
           console.error(err)
         } else {
@@ -139,7 +103,7 @@ module.exports = function (app) {
     }
     if (options && options.enabled) {
       debug('Starting plugin ' + pluginName)
-      plugin.start(getPluginOptions(plugin.id).configuration, restart)
+      plugin.start(options.configuration, restart)
     }
     app.plugins.push(plugin)
 
@@ -148,7 +112,7 @@ module.exports = function (app) {
 
     var router = express.Router()
     router.get('/', (req, res) => {
-      const options = getPluginOptions(plugin.id)
+      const options = app.getPluginOptions(plugin.id)
       res.json({
         enabled: options.enabled,
         id: plugin.id,
@@ -158,7 +122,7 @@ module.exports = function (app) {
     })
 
     router.post('/config', (req, res) => {
-      savePluginOptions(plugin.id, req.body, err => {
+      app.savePluginOptions(plugin.id, req.body, err => {
         if (err) {
           console.log(err)
           res.status(500)
@@ -167,7 +131,7 @@ module.exports = function (app) {
         }
         res.send('Saved configuration for plugin ' + plugin.id)
         plugin.stop()
-        const options = getPluginOptions(plugin.id)
+        const options = app.getPluginOptions(plugin.id)
         if (options.enabled) {
           plugin.start(options.configuration, restart)
         }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@signalk/signalk-schema": "0.0.1-12",
     "@signalk/signalk-to-nmea0183": "0.1.1",
     "@signalk/simplegauges": "^1.0.1",
+    "@signalk/sk-simple-token-security-config": "^1.3.0",
     "baconjs": "^0.7.88",
     "body-parser": "^1.14.1",
     "colors": "^1.1.2",


### PR DESCRIPTION
I also moved the two security plugins to the SignalK git.
Please publish those and/or give me permission to publish @signalk npm's (if possible)

Changes on the plugin side include generating the secret key at startup if non specified and prompting the user to create an admin username and password the first time the site is hit.