### PR TITLE
fix: less strict certificate file permission check

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -124,7 +124,7 @@ function hasStrictPermissions (stat) {
   if (process.platform == 'win32') {
     return new Mode(stat).toString() === '-r--r--r--'
   } else {
-    return new Mode(stat).toString() === '-r--------'
+    return /^-r[-w][-x]------$/.test(new Mode(stat).toString())
   }
 }
 
@@ -157,9 +157,9 @@ function createCertificateOptions (app, certFile, keyFile, cb) {
         throw err
       } else {
         fs.writeFileSync(keyFile, keys.serviceKey)
-        fs.chmodSync(keyFile, '400')
+        fs.chmodSync(keyFile, '600')
         fs.writeFileSync(certFile, keys.certificate)
-        fs.chmodSync(certFile, '400')
+        fs.chmodSync(certFile, '600')
         cb(null, {
           key: keys.serviceKey,
           cert: keys.certificate


### PR DESCRIPTION
Check that others have no access to certificate files and we have
at least read access. This allows us, for example in form
of a plugin, to write/update certificate files.

If the server generates self signed certificate files save them with 600 permissions.