### PR TITLE
fix: use correct port values in api, refactor port handling

### DIFF
--- a/lib/ports.js
+++ b/lib/ports.js
@@ -16,6 +16,12 @@
 
 const SD_LISTEN_FDS_START = 3
 
+const getSslPort = app =>
+  Number(process.env.SSLPORT) || app.config.settings.sslport || 3443
+
+const getHttpPort = app =>
+  Number(process.env.PORT) || app.config.settings.port || 3000
+
 module.exports = {
   getPrimaryPort: function (app) {
     if (process.env.LISTEN_FDS > 0) {
@@ -23,9 +29,7 @@ module.exports = {
         fd: SD_LISTEN_FDS_START
       }
     }
-    return app.config.settings.ssl
-      ? Number(process.env.SSLPORT) || app.config.settings.sslport || 3443
-      : Number(process.env.PORT) || app.config.settings.port || 3000
+    return app.config.settings.ssl ? getSslPort(app) : getHttpPort(app)
   },
 
   getSecondaryPort: function (app) {
@@ -37,17 +41,16 @@ module.exports = {
         fd: SD_LISTEN_FDS_START + 1
       }
     }
-    return app.config.settings.ssl
-      ? Number(process.env.PORT) || app.config.settings.port || 3000
-      : -7777
+    return app.config.settings.ssl ? getHttpPort(app) : -7777
   },
 
   getExternalPort: function (app) {
     if (process.env.EXTERNALPORT > 0) {
       return Number(process.env.EXTERNALPORT)
     }
-    return app.config.settings.ssl
-      ? Number(process.env.SSLPORT) || app.config.settings.sslport || 3443
-      : Number(process.env.PORT) || app.config.settings.port || 3000
-  }
+    return app.config.settings.ssl ? getSslPort(app) : getHttpPort(app)
+  },
+
+  getSslPort,
+  getHttpPort
 }

--- a/lib/serverroutes.js
+++ b/lib/serverroutes.js
@@ -20,6 +20,7 @@ const debug = require('debug')('signalk-server:serverroutes')
 const path = require('path')
 const _ = require('lodash')
 const config = require('./config/config')
+const { getHttpPort, getSslPort } = require('./ports')
 
 const defaultSecurityStrategy = '@signalk/sk-simple-token-security'
 
@@ -310,8 +311,8 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
         mdns: app.config.settings.mdns
       },
       loggingDirectory: app.config.settings.loggingDirectory || '/tmp',
-      port: app.config.settings.port || 3000,
-      sslport: app.config.settings.sslport || 3433
+      port: getHttpPort(app),
+      sslport: getSslPort(app)
     }
 
     var availableInterfaces = require('./interfaces')


### PR DESCRIPTION
Extract functions for http and ssl ports and use
them instead of copied code.