### PR TITLE
fix: remove unwarranted charts error message

### DIFF
--- a/lib/interfaces/charts.js
+++ b/lib/interfaces/charts.js
@@ -24,12 +24,11 @@ const apiPathPrefix = pathPrefix + versionPrefix + '/api/'
 const parseStringAsync = Promise.promisify(require('xml2js').parseString)
 const path = require('path')
 const express = require('express')
-var chartBaseDir
 
 const chartProviders = {}
-loadCharts()
 
 module.exports = function (app) {
+  let chartBaseDir
   const api = {}
 
   api.start = function () {
@@ -43,7 +42,7 @@ module.exports = function (app) {
     }
 
     app.get(apiPathPrefix + 'resources/charts/*', (req, res, next) => {
-      loadCharts(app, req).then(charts => {
+      loadCharts(chartBaseDir, app, req).then(charts => {
         var parts = req.path.split('/')
         var chart_parts = parts.slice(6)
 
@@ -56,7 +55,7 @@ module.exports = function (app) {
     })
 
     app.get(apiPathPrefix + 'resources/charts', (req, res, next) => {
-      loadCharts(app, req)
+      loadCharts(chartBaseDir, app, req)
         .then(charts => {
           res.json(charts)
         })
@@ -93,44 +92,50 @@ module.exports = function (app) {
   return api
 }
 
-function loadCharts (app, req) {
+function loadCharts (chartBaseDir, app, req) {
   return fs
     .readdirAsync(chartBaseDir)
     .then(files => {
       return Promise.props(
-        files.reduce((acc, file) => {
-          acc[file] = fs
-            .statAsync(path.join(chartBaseDir, file))
-            .then(stat => {
-              if (stat.isDirectory()) {
-                return directoryToMapInfo(file)
-              } else {
-                return fileToMapInfo(file)
-              }
-            })
-            .catch(err => {
-              console.error(err + ' ' + file)
-              if (
-                err.toString() === "Error: Cannot find module '@mapbox/mbtiles'"
-              ) {
-                console.error(
-                  'For mbtiles support please run npm install @mapbox/mbtiles'
-                )
-              }
-              return undefined
-            })
-          return acc
-        }, {})
+        files
+          .map(filename => ({
+            filename,
+            fullFilename: path.join(chartBaseDir, filename)
+          }))
+          .reduce((acc, { filename, fullFilename }) => {
+            acc[filename] = fs
+              .statAsync(fullFilename)
+              .then(stat => {
+                if (stat.isDirectory()) {
+                  return directoryToMapInfo(fullFilename, filename)
+                } else {
+                  return fileToMapInfo(fullFilename, filename)
+                }
+              })
+              .catch(err => {
+                console.error(err + ' ' + filename)
+                if (
+                  err.toString() ===
+                  "Error: Cannot find module '@mapbox/mbtiles'"
+                ) {
+                  console.error(
+                    'For mbtiles support please run npm install @mapbox/mbtiles'
+                  )
+                }
+                return undefined
+              })
+            return acc
+          }, {})
       )
     })
     .catch(err => {
-      console.error('Error reading ' + chartBaseDir)
+      console.error(err.message)
       return {}
     })
 }
 
-function directoryToMapInfo (dir) {
-  const resourceFile = path.join(chartBaseDir, dir, 'tilemapresource.xml')
+function directoryToMapInfo (fullDirname, dirname) {
+  const resourceFile = path.join(fullDirname, 'tilemapresource.xml')
   return fs
     .readFileAsync(resourceFile)
     .then(resXml => {
@@ -145,10 +150,10 @@ function directoryToMapInfo (dir) {
       }
 
       return {
-        identifier: dir,
+        identifier: dirname,
         name: result.Title[0],
         description: result.Title[0],
-        tilemapUrl: '/mapcache/' + dir,
+        tilemapUrl: '/mapcache/' + dirname,
         scale: parseInt(scale)
       }
     })
@@ -158,11 +163,11 @@ function directoryToMapInfo (dir) {
     })
 }
 
-function fileToMapInfo (file) {
-  debug(chartBaseDir + ' ' + file)
+function fileToMapInfo (fullFilename, filename) {
+  debug(fullFilename)
   return new Promise((resolve, reject) => {
     const MBTiles = require('@mapbox/mbtiles')
-    new MBTiles(path.join(chartBaseDir, file), (err, mbtiles) => {
+    new MBTiles(fullFilename, (err, mbtiles) => {
       if (err) {
         reject(err)
         return
@@ -176,16 +181,16 @@ function fileToMapInfo (file) {
           resolve(undefined)
           return
         }
-        chartProviders[file] = mbtiles
+        chartProviders[filename] = mbtiles
         resolve({
-          identifier: file,
+          identifier: filename,
           name: mbtilesData.name || mbtilesData.id,
           description: mbtilesData.description,
           bounds: mbtilesData.bounds,
           minzoom: mbtilesData.minzoom,
           maxzoom: mbtilesData.maxzoom,
           format: mbtilesData.format,
-          tilemapUrl: '/charts/' + file + '/{z}/{x}/{y}',
+          tilemapUrl: '/charts/' + filename + '/{z}/{x}/{y}',
           type: 'tilelayer',
           scale: '250000'
         })


### PR DESCRIPTION
Rework chart loading logic to be more straightforward
and remove the braindead eager load that must have
never worked, just caused an extra error message that
confuses people."