### PR TITLE
fix: make plugins installed in config directory are preferred

### DIFF
--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -148,7 +148,7 @@ module.exports = function (app) {
   }
 
   function registerPlugin (app, pluginName, metadata, location) {
-    debug('Registering plugin ' + pluginName)
+    debug(`Registering plugin ${pluginName} from ${location}`)
     const appCopy = _.assign({}, app)
     const plugin = require(path.join(location, pluginName))(appCopy)
     appCopy.handleMessage = handleMessageWrapper(app, plugin.id)

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -33,7 +33,13 @@ function modulesWithKeyword (app, keyword) {
 
   res.push.apply(
     res,
-    findModulesInDir(__dirname + '/../node_modules/', keyword)
+    findModulesInDir(__dirname + '/../node_modules/', keyword).filter(
+      module => {
+        return !res.find(m => {
+          return m.module == module.module
+        })
+      }
+    )
   )
 
   return res


### PR DESCRIPTION

If a plugin is installed under the config/settings directory and also installed under the servers node_modules directory, plugin gets started twice and listed in the config UI twice.

This changes makes so that only the plugin in the config directory is used in this case.