### PR TITLE
feature: support relativePosition.radius in subscriptions and REST requests

### DIFF
--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -18,6 +18,8 @@ const debug = require('debug')('signalk-server:interfaces:rest')
 const express = require('express')
 const { getMetadata, getUnits } = require('@signalk/signalk-schema')
 const ports = require('../ports')
+const geolib = require('geolib')
+const _ = require('lodash')
 
 module.exports = function (app) {
   'use strict'
@@ -71,15 +73,45 @@ module.exports = function (app) {
             return
           }
         }
+        if (
+          path.length == 1 &&
+          path[0] === 'vessels' &&
+          req.query.radius &&
+          req.query.latitude &&
+          req.query.longitude
+        ) {
+          debug(`radius query: ${req.query.radius}`)
 
-        for (var i in path) {
-          var p = path[i]
+          var vessels = {}
 
-          if (typeof last[p] !== 'undefined') {
-            last = last[p]
-          } else {
-            next()
-            return
+          _.forIn(data.vessels, (value, key) => {
+            var position = _.get(value, 'navigation.position')
+
+            if (position) {
+              if (
+                geolib.isPointInCircle(
+                  position.value,
+                  req.query,
+                  req.query.radius
+                )
+              ) {
+                debug(`vessel: ${key} ${JSON.stringify(position)}`)
+                vessels[key] = value
+              }
+            }
+          })
+
+          return res.json(vessels)
+        } else {
+          for (var i in path) {
+            var p = path[i]
+
+            if (typeof last[p] !== 'undefined') {
+              last = last[p]
+            } else {
+              next()
+              return
+            }
           }
         }
 

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -97,9 +97,19 @@ module.exports = function (app) {
             debug('security disallowed update')
             return
           }
+          if (spark.request.position) {
+            // if this has a relativePosition subscription, update the position
+            updatePosition(msg, spark)
+          }
           app.handleMessage(spark.request.source || 'ws', msg)
         }
         if (msg.subscribe) {
+          if (!_.isUndefined(msg.context.relativePosition)) {
+            debug('setting up to store position')
+            spark.request.position = {}
+            msg.context.relativePosition.position = spark.request.position
+          }
+
           app.subscriptionmanager.subscribe(
             msg,
             unsubscribes,
@@ -227,4 +237,17 @@ function normalizeUpdate (update) {
       values: [value]
     }
   })
+}
+
+function updatePosition (delta, spark) {
+  if (delta.updates) {
+    delta.updates.forEach(update => {
+      update.values.forEach(valuePath => {
+        if (valuePath.path && valuePath.path === 'navigation.position') {
+          spark.request.position.latitude = valuePath.value.latitude
+          spark.request.position.longitude = valuePath.value.longitude
+        }
+      })
+    })
+  }
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -97,19 +97,9 @@ module.exports = function (app) {
             debug('security disallowed update')
             return
           }
-          if (spark.request.position) {
-            // if this has a relativePosition subscription, update the position
-            updatePosition(msg, spark)
-          }
           app.handleMessage(spark.request.source || 'ws', msg)
         }
         if (msg.subscribe) {
-          if (!_.isUndefined(msg.context.relativePosition)) {
-            debug('setting up to store position')
-            spark.request.position = {}
-            msg.context.relativePosition.position = spark.request.position
-          }
-
           app.subscriptionmanager.subscribe(
             msg,
             unsubscribes,
@@ -237,17 +227,4 @@ function normalizeUpdate (update) {
       values: [value]
     }
   })
-}
-
-function updatePosition (delta, spark) {
-  if (delta.updates) {
-    delta.updates.forEach(update => {
-      update.values.forEach(valuePath => {
-        if (valuePath.path && valuePath.path === 'navigation.position') {
-          spark.request.position.latitude = valuePath.value.latitude
-          spark.request.position.longitude = valuePath.value.longitude
-        }
-      })
-    })
-  }
 }

--- a/lib/subscriptionmanager.js
+++ b/lib/subscriptionmanager.js
@@ -16,12 +16,13 @@
 
 const _ = require('lodash')
 const Bacon = require('baconjs')
-
+const geolib = require('geolib')
 const debug = require('debug')('signalk-server:subscriptionmanager')
 
 function SubscriptionManager (app) {
   this.streambundle = app.streambundle
   this.selfContext = app.selfContext
+  this.app = app
 }
 
 SubscriptionManager.prototype.subscribe = function (
@@ -30,7 +31,12 @@ SubscriptionManager.prototype.subscribe = function (
   errorCallback,
   callback
 ) {
-  const contextFilter = contextMatcher(this.selfContext, command)
+  const contextFilter = contextMatcher(
+    this.selfContext,
+    this.app,
+    command,
+    errorCallback
+  )
   if (Array.isArray(command.subscribe)) {
     handleSubscribeRows(
       command.subscribe,
@@ -153,16 +159,29 @@ function pathMatcher (path) {
   return aPath => matcher.test(aPath)
 }
 
-function contextMatcher (selfContext, subscribeCommand) {
+function contextMatcher (selfContext, app, subscribeCommand, errorCallback) {
   debug('subscribeCommand:' + JSON.stringify(subscribeCommand))
-  var pattern = subscribeCommand.context.replace('.', '\\.').replace('*', '.*')
-  var matcher = new RegExp('^' + pattern + '$')
   if (subscribeCommand.context) {
-    return normalizedDeltaData =>
-      matcher.test(normalizedDeltaData.context) ||
-      ((subscribeCommand.context === 'vessels.self' ||
-        subscribeCommand.context === 'self') &&
-        normalizedDeltaData.context === selfContext)
+    if (_.isString(subscribeCommand.context)) {
+      var pattern = subscribeCommand.context
+        .replace('.', '\\.')
+        .replace('*', '.*')
+      var matcher = new RegExp('^' + pattern + '$')
+      return normalizedDeltaData =>
+        matcher.test(normalizedDeltaData.context) ||
+        ((subscribeCommand.context === 'vessels.self' ||
+          subscribeCommand.context === 'self') &&
+          normalizedDeltaData.context === selfContext)
+    } else if (_.get(subscribeCommand.context, 'relativePosition')) {
+      var relativePosition = subscribeCommand.context.relativePosition
+      if (!_.get(relativePosition, 'radius')) {
+        errorCallback('Please specify a radius for relativePosition')
+        return x => false
+      }
+      return normalizedDeltaData => {
+        return checkPosition(app, relativePosition, normalizedDeltaData)
+      }
+    }
   }
   return x => true
 }
@@ -184,6 +203,27 @@ function toDelta (normalizedDeltaData) {
       }
     ]
   }
+}
+
+function checkPosition (app, relativePosition, normalizedDeltaData) {
+  var vessel = _.get(app.signalk.root, normalizedDeltaData.context)
+  var position = _.get(vessel, 'navigation.position')
+
+  var subsPosition = _.get(relativePosition, 'position')
+  if (
+    position &&
+    subsPosition &&
+    subsPosition.latitude &&
+    subsPosition.longitude
+  ) {
+    return geolib.isPointInCircle(
+      position.value,
+      subsPosition,
+      relativePosition.radius
+    )
+  }
+
+  return false
 }
 
 module.exports = SubscriptionManager

--- a/lib/subscriptionmanager.js
+++ b/lib/subscriptionmanager.js
@@ -174,8 +174,14 @@ function contextMatcher (selfContext, app, subscribeCommand, errorCallback) {
           normalizedDeltaData.context === selfContext)
     } else if (_.get(subscribeCommand.context, 'relativePosition')) {
       var relativePosition = subscribeCommand.context.relativePosition
-      if (!_.get(relativePosition, 'radius')) {
-        errorCallback('Please specify a radius for relativePosition')
+      if (
+        !_.get(relativePosition, 'radius') ||
+        !_.get(relativePosition, 'position.latitude') ||
+        !_.get(relativePosition, 'position.longitude')
+      ) {
+        errorCallback(
+          'Please specify a radius and position for relativePosition'
+        )
         return x => false
       }
       return normalizedDeltaData => {

--- a/lib/subscriptionmanager.js
+++ b/lib/subscriptionmanager.js
@@ -172,12 +172,11 @@ function contextMatcher (selfContext, app, subscribeCommand, errorCallback) {
         ((subscribeCommand.context === 'vessels.self' ||
           subscribeCommand.context === 'self') &&
           normalizedDeltaData.context === selfContext)
-    } else if (_.get(subscribeCommand.context, 'relativePosition')) {
-      var relativePosition = subscribeCommand.context.relativePosition
+    } else if (_.get(subscribeCommand.context, 'radius')) {
       if (
-        !_.get(relativePosition, 'radius') ||
-        !_.get(relativePosition, 'position.latitude') ||
-        !_.get(relativePosition, 'position.longitude')
+        !_.get(subscribeCommand.context, 'radius') ||
+        !_.get(subscribeCommand.context, 'position.latitude') ||
+        !_.get(subscribeCommand.context, 'position.longitude')
       ) {
         errorCallback(
           'Please specify a radius and position for relativePosition'
@@ -185,7 +184,7 @@ function contextMatcher (selfContext, app, subscribeCommand, errorCallback) {
         return x => false
       }
       return normalizedDeltaData => {
-        return checkPosition(app, relativePosition, normalizedDeltaData)
+        return checkPosition(app, subscribeCommand.context, normalizedDeltaData)
       }
     }
   }
@@ -211,22 +210,18 @@ function toDelta (normalizedDeltaData) {
   }
 }
 
-function checkPosition (app, relativePosition, normalizedDeltaData) {
+function checkPosition (app, context, normalizedDeltaData) {
   var vessel = _.get(app.signalk.root, normalizedDeltaData.context)
   var position = _.get(vessel, 'navigation.position')
 
-  var subsPosition = _.get(relativePosition, 'position')
+  var subsPosition = _.get(context, 'position')
   if (
     position &&
     subsPosition &&
     subsPosition.latitude &&
     subsPosition.longitude
   ) {
-    return geolib.isPointInCircle(
-      position.value,
-      subsPosition,
-      relativePosition.radius
-    )
+    return geolib.isPointInCircle(position.value, subsPosition, context.radius)
   }
 
   return false

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,32 +96,6 @@
       "integrity": "sha512-aalIRUtcR6nPf50kEwnYvepSJIdpulrbMeeNMwiOmFgBg4MgScCmlI7SqOmsGJNqaH65+benoqt0H4N0RR2Okg==",
       "dev": true
     },
-    "@signalk/aisreporter": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@signalk/aisreporter/-/aisreporter-0.0.3.tgz",
-      "integrity": "sha1-SLhaXEvhZwuOIRJ2BRuxCiqF8mo=",
-      "requires": {
-        "baconjs": "0.7.95",
-        "debug": "2.6.9",
-        "ggencoder": "0.1.20",
-        "lodash": "4.17.4"
-      },
-      "dependencies": {
-        "baconjs": {
-          "version": "0.7.95",
-          "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-0.7.95.tgz",
-          "integrity": "sha512-3qp0GuAfEUlJybSVPQ2oai8VYO0aSTJf4wP/jYZpgaffEXi31VBcqSlVmD8ahmXXGzgdO+yFk9onDnt2ZJJXxA=="
-        },
-        "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "@signalk/client": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@signalk/client/-/client-0.2.1.tgz",
@@ -346,9 +320,9 @@
       "integrity": "sha1-U3QBxoUf5iJBJzFbJXL7MwkV73s="
     },
     "@signalk/sk-simple-token-security": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@signalk/sk-simple-token-security/-/sk-simple-token-security-2.2.2.tgz",
-      "integrity": "sha1-36KHKMazzbtVFT4s4eB20ZpqMdg=",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@signalk/sk-simple-token-security/-/sk-simple-token-security-2.2.3.tgz",
+      "integrity": "sha512-O7EjM0dzFRSLF3qeiVArg9cqFVpqa4m0EvIOlnkXkL8HMRGQwDWQQHwNAz1pG/US8yNhfFI6fENqCRRkKfLujg==",
       "requires": {
         "bcrypt": "1.0.3",
         "body-parser": "1.18.2",
@@ -746,9 +720,9 @@
       "dev": true
     },
     "baconjs": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-2.0.0.tgz",
-      "integrity": "sha1-kLsBPtXGyMJtVnlsns9bkCo9rbY="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-1.0.1.tgz",
+      "integrity": "sha512-f4YHGKrxagnsgzrd5E33VIcfTJaFBgBwvwINP0vi0mJW9Rddjda6sG/ICBeT5a5foZmqwWDhRbWpbSH+TLVKxw=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -920,9 +894,9 @@
       }
     },
     "canboatjs": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/canboatjs/-/canboatjs-0.0.3.tgz",
-      "integrity": "sha512-MO+V6V7U/ca6RArUhZoYoHiC7o4QJF/O6/FJOlJwhUlgkVqCymQcXicsvyo7ZUfVrtZntmvR1hHnDjLUWMukLQ==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/canboatjs/-/canboatjs-0.0.9.tgz",
+      "integrity": "sha512-f7yJv9ehRpBwx7q5VpVEZmXQhwgJFJvDO5ySEbcPofBzUILzD+jbK0q9MLMnpgoQlTpbS/wFRARSbCqb492DeA==",
       "requires": {
         "bit-buffer": "0.2.3",
         "debug": "3.1.0",
@@ -2154,6 +2128,11 @@
         "strip-ansi": "3.0.1",
         "wide-align": "1.1.2"
       }
+    },
+    "geolib": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-2.0.24.tgz",
+      "integrity": "sha512-NR0AyYyEnGrFS9JvSFmmotQDxVCORJgDHdvBwSatxl5aHarOLMh3KuGI83bCvCfObjfoEiDe8Ung8GGLGAtthw=="
     },
     "get-func-name": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "express-namespace": "^0.1.1",
     "file-timestamp-stream": "0.1.0",
     "flatmap": "0.0.3",
+    "geolib": "^2.0.24",
     "lodash": "^4.17.4",
     "minimist": "^1.1.0",
     "moment": "^2.10.6",

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -438,7 +438,11 @@ describe('Subscriptions', _ => {
         return wsPromiser.send({
           context: {
             relativePosition: {
-              radius: 1
+              radius: 1,
+              position: {
+                longitude: -76.4639314,
+                latitude: 39.0700403
+              }
             }
           },
           subscribe: [
@@ -448,16 +452,11 @@ describe('Subscriptions', _ => {
           ]
         })
       })
-      .then(() => {
+      .then(results => {
         return Promise.all([
           wsPromiser.nextMsg(),
-          wsPromiser.send(
-            getClosePosistionDelta({ context: 'vessels.' + self })
-          )
+          sendDelta(getClosePosistionDelta())
         ])
-      })
-      .then(results => {
-        return sendDelta(getClosePosistionDelta())
       })
       .then(results => {
         return Promise.all([

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -437,12 +437,10 @@ describe('Subscriptions', _ => {
 
         return wsPromiser.send({
           context: {
-            relativePosition: {
-              radius: 1,
-              position: {
-                longitude: -76.4639314,
-                latitude: 39.0700403
-              }
+            radius: 1,
+            position: {
+              longitude: -76.4639314,
+              latitude: 39.0700403
             }
           },
           subscribe: [

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -73,6 +73,62 @@ function getNameDelta (overwrite) {
   return _.assign(delta, overwrite)
 }
 
+function getClosePosistionDelta (overwrite) {
+  const delta = {
+    updates: [
+      {
+        source: {
+          label: 'langford-canboatjs',
+          type: 'NMEA2000',
+          pgn: 129025,
+          src: '3'
+        },
+        timestamp: '2017-04-15T14:58:01.200Z',
+        values: [
+          {
+            path: 'navigation.position',
+            value: {
+              longitude: -76.4639314,
+              latitude: 39.0700403
+            }
+          }
+        ]
+      }
+    ],
+    context: 'vessels.closeVessel'
+  }
+
+  return _.assign(delta, overwrite)
+}
+
+function getFarPosistionDelta () {
+  const delta = {
+    updates: [
+      {
+        source: {
+          label: 'langford-canboatjs',
+          type: 'NMEA2000',
+          pgn: 129025,
+          src: '3'
+        },
+        timestamp: '2017-04-15T14:58:01.200Z',
+        values: [
+          {
+            path: 'navigation.position',
+            value: {
+              longitude: -76.4639314,
+              latitude: 39.0700503
+            }
+          }
+        ]
+      }
+    ],
+    context: 'vessels.farVessel'
+  }
+
+  return delta
+}
+
 describe('Subscriptions', _ => {
   var serverP, port, deltaUrl
 
@@ -363,6 +419,69 @@ describe('Subscriptions', _ => {
         assert(delta.updates[0].values.length === 1, 'Receives just one value')
         assert(delta.updates[0].values[0].path === '', 'Receives just name')
         assert(delta.context === 'vessels.othervessel')
+      })
+  })
+
+  it('relativePosition subscription serves correct data', function () {
+    var self, wsPromiser
+
+    return serverP
+      .then(_ => {
+        wsPromiser = new WsPromiser(
+          'ws://localhost:' + port + '/signalk/v1/stream?subsribe=none'
+        )
+        return wsPromiser.nextMsg()
+      })
+      .then(wsHello => {
+        self = JSON.parse(wsHello).self
+
+        return wsPromiser.send({
+          context: {
+            relativePosition: {
+              radius: 1
+            }
+          },
+          subscribe: [
+            {
+              path: 'navigation.position'
+            }
+          ]
+        })
+      })
+      .then(() => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          wsPromiser.send(
+            getClosePosistionDelta({ context: 'vessels.' + self })
+          )
+        ])
+      })
+      .then(results => {
+        return sendDelta(getClosePosistionDelta())
+      })
+      .then(results => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          sendDelta(getClosePosistionDelta())
+        ])
+      })
+      .then(results => {
+        const delta = JSON.parse(results[0])
+
+        assert(delta.updates.length === 1, 'Receives just one update')
+        assert(delta.updates[0].values.length === 1, 'Receives just one value')
+        assert(delta.context === 'vessels.closeVessel')
+
+        return sendDelta(getFarPosistionDelta())
+      })
+      .then(results => {
+        return Promise.all([
+          wsPromiser.nextMsg(),
+          sendDelta(getFarPosistionDelta())
+        ])
+      })
+      .then(results => {
+        assert(results[0] === 'timeout')
       })
   })
 })


### PR DESCRIPTION
This feature allows ws subscriptions to be based on the relative position of the vessel. This allows the client to to only get information about other vessels that are within a specific distance. For example:

```
{
  context: {
    radius: 10,
    position: {
      longitude: -76.4639314,
      latitude: 39.0700403
    }
  },
  subscribe: [
    {
      path: 'navigation.*'
    }
  ]
}
```

