### PR TITLE
Debian package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ plugin-config/public/
 
 *.tgz
 work/
+
+#debian packages
+*.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
         skip_cleanup: true
         package_glob: signalk-server*.deb
         on:
-          all_branches: true
+          branch: master
       - provider: packagecloud
         repository: signalk-server
         username: SignalK
@@ -77,4 +77,4 @@ jobs:
         skip_cleanup: true
         package_glob: signalk-server*.deb
         on:
-          all_branches: true
+          branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,74 @@ env:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+    - ubuntu-toolchain-r-test
     packages:
-      - g++-4.8
+    - g++-4.8
+    - jq
+    - fakeroot
+    - dpkg
+    - libavahi-compat-libdnssd-dev
+jobs:
+  include:
+
+  - stage: test
+    script: npm test
+
+  - stage: build-deb-branch
+    before_install:
+    - npm install -g node-deb
+    before_script:
+        - "PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')"
+        - node-deb --verbose -n "signalk-server-${TRAVIS_BRANCH}" -v "${PACKAGE_VERSION}-snapshot-${TRAVIS_BUILD_NUMBER}" -- index.js `find . -maxdepth 1 -type d | grep -v .git | grep -v node_modules | egrep -v '^\.$'`
+    script: ls -lh *.deb ; dpkg-deb --info *.deb
+    deploy:
+      - provider: packagecloud
+        repository: signalk-server
+        username: SignalK 
+        token:
+          secure: 
+        dist: debian/stretch
+        skip_cleanup: true
+        package_glob: signalk-server*.deb
+        on:
+          all_branches: true
+      - provider: packagecloud
+        repository: signalk-server
+        username: SignalK
+        token:
+          secure: 
+        dist: raspbian/stretch
+        skip_cleanup: true
+        package_glob: signalk-server*.deb
+        on:
+          all_branches: true
+
+  - stage: build-deb-main
+    if: tag =~ ^v[0-9]
+    before_install:
+    - npm install -g node-deb
+    before_script:
+        - "PACKAGE_VERSION=$(cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[\",]//g' | tr -d '[[:space:]]')"
+        - node-deb --verbose -n "signalk-server" -v "${PACKAGE_VERSION}" -- index.js `find . -maxdepth 1 -type d | grep -v .git | grep -v node_modules | egrep -v '^\.$'`
+    script: ls -lh *.deb ; dpkg-deb --info *.deb
+    deploy:
+      - provider: packagecloud
+        repository: signalk-server
+        username: SignalK 
+        token:
+          secure: 
+        dist: debian/stretch
+        skip_cleanup: true
+        package_glob: signalk-server*.deb
+        on:
+          all_branches: true
+      - provider: packagecloud
+        repository: signalk-server
+        username: SignalK
+        token:
+          secure: 
+        dist: raspbian/stretch
+        skip_cleanup: true
+        package_glob: signalk-server*.deb
+        on:
+          all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
         repository: signalk-server
         username: SignalK 
         token:
-          secure: 
+          secure:  "bKa9NU3sPNHxISTrYOuAOfJgZLuKXpywnHFjkOIvcrk1hu5NFqTcVGj7IGtOO93GU2rNmZqWl9WLSICYQZMZ7tL9Lfnj2AH3bU7JT9C8vbMtIc31FajKbPK81lhCDzSa5G3Y0SkyqwCGWdPfSHXeGR5sbQoWsSoTOhMOXP80hqc="
         dist: debian/stretch
         skip_cleanup: true
         package_glob: signalk-server*.deb
@@ -42,7 +42,7 @@ jobs:
         repository: signalk-server
         username: SignalK
         token:
-          secure: 
+          secure:  "bKa9NU3sPNHxISTrYOuAOfJgZLuKXpywnHFjkOIvcrk1hu5NFqTcVGj7IGtOO93GU2rNmZqWl9WLSICYQZMZ7tL9Lfnj2AH3bU7JT9C8vbMtIc31FajKbPK81lhCDzSa5G3Y0SkyqwCGWdPfSHXeGR5sbQoWsSoTOhMOXP80hqc="
         dist: raspbian/stretch
         skip_cleanup: true
         package_glob: signalk-server*.deb
@@ -62,7 +62,7 @@ jobs:
         repository: signalk-server
         username: SignalK 
         token:
-          secure: 
+          secure:  "bKa9NU3sPNHxISTrYOuAOfJgZLuKXpywnHFjkOIvcrk1hu5NFqTcVGj7IGtOO93GU2rNmZqWl9WLSICYQZMZ7tL9Lfnj2AH3bU7JT9C8vbMtIc31FajKbPK81lhCDzSa5G3Y0SkyqwCGWdPfSHXeGR5sbQoWsSoTOhMOXP80hqc="
         dist: debian/stretch
         skip_cleanup: true
         package_glob: signalk-server*.deb
@@ -72,7 +72,7 @@ jobs:
         repository: signalk-server
         username: SignalK
         token:
-          secure: 
+          secure:  "bKa9NU3sPNHxISTrYOuAOfJgZLuKXpywnHFjkOIvcrk1hu5NFqTcVGj7IGtOO93GU2rNmZqWl9WLSICYQZMZ7tL9Lfnj2AH3bU7JT9C8vbMtIc31FajKbPK81lhCDzSa5G3Y0SkyqwCGWdPfSHXeGR5sbQoWsSoTOhMOXP80hqc="
         dist: raspbian/stretch
         skip_cleanup: true
         package_glob: signalk-server*.deb

--- a/package.json
+++ b/package.json
@@ -80,6 +80,22 @@
   "engines": {
     "node": ">=8"
   },
+  "node_deb": {
+    "description": "Signalk Server",
+    "entrypoints": {
+      "daemon":  "bin/signalk-server -c /etc/signalk-server"
+    },
+    "architecture": "all",
+    "user": "signalk-server",
+    "group": "signalk-server",
+    "executable_name": "signalk-server",
+    "dependencies": "build-essential,libavahi-compat-libdnssd-dev,libnss-mdns,avahi-utils",
+    "install_strategy": "auto",
+    "templates": {
+	    "postinst": "util/postinstall.sh"
+    }
+
+  },
   "dependencies": {
     "@signalk/client": "^0.2.0",
     "@signalk/freeboard-sk": "0.0.1",

--- a/util/postinstall.sh
+++ b/util/postinstall.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Signalk postInstall script. Based on node-deb template
+set -e
+set -o pipefail
+
+declare -r init_type='{{ node_deb_init }}'
+declare -ri no_rebuild='{{ node_deb_no_rebuild }}'
+declare -r install_strategy='{{ install_strategy }}'
+
+add_user() {
+  : "${1:?'User was not defined'}"
+  declare -r user="$1"
+  declare -r uid="$2"
+
+  if [ -z "$uid" ]; then
+    declare -r uid_flags=""
+  else
+    declare -r uid_flags="--uid $uid"
+  fi
+
+  declare -r group="${3:-$user}"
+  declare -r descr="${4:-No description}"
+  declare -r shell="${5:-/bin/false}"
+
+  if ! getent passwd | grep -q "^$user:"; then
+    echo "Creating system user: $user in $group with $descr and shell $shell"
+    useradd $uid_flags --gid $group --system --shell $shell -c "$descr" -m $user
+  fi
+}
+
+add_group() {
+  : "${1:?'Group was not defined'}"
+  declare -r group="$1"
+  declare -r gid="$2"
+
+  if [ -z "$gid" ]; then
+    declare -r gid_flags=""
+  else
+    declare -r gid_flags="--gid $gid"
+  fi
+
+  if ! getent group | grep -q "^$group:" ; then
+    echo "Creating system group: $group"
+    groupadd $gid_flags --system $group
+  fi
+}
+
+start_service () {
+  : "${1:?'Service name was not defined'}"
+  declare -r service_name="$1"
+
+  if hash systemctl 2> /dev/null; then
+    if [[ "$init_type" == 'auto' || "$init_type" == 'systemd' ]]; then
+      {
+        systemctl enable "$service_name.service" && \
+        systemctl start "$service_name.service"
+      } || echo "$service_name could not be registered or started"
+    fi
+  elif hash service 2> /dev/null; then
+    if [[ "$init_type" == 'auto' || "$init_type" == 'upstart' || "$init_type" == 'sysv' ]]; then
+      service "$service_name" start || echo "$service_name could not be registered or started"
+    fi
+  elif hash start 2> /dev/null; then
+    if [[ "$init_type" == 'auto' || "$init_type" == 'upstart' ]]; then
+      start "$service_name" || echo "$service_name could not be registered or started"
+    fi
+  elif hash update-rc.d 2> /dev/null; then
+    if [[ "$init_type" == 'auto' || "$init_type" == 'sysv' ]]; then
+      {
+        update-rc.d "$service_name" defaults && \
+        "/etc/init.d/$service_name" start
+      } || echo "$service_name could not be registered or started"
+    fi
+  else
+    echo 'Your system does not appear to use systemd, Upstart, or System V, so the service could not be started'
+  fi
+}
+
+dependency_install() {
+  : "${1:?'Package name was not defined'}"
+  cd "/usr/share/$1/app"
+
+  case $install_strategy in
+    auto)
+      if hash npm 2> /dev/null; then
+        if [ ! -d './node_modules' ]; then
+          echo "Directory 'node_modules' did not exist. Running 'npm install'"
+          npm install --production
+        else
+          if [ "$no_rebuild" -eq 0 ]; then
+	    echo "Installint node-pre-gyp in order to compile node libraries"
+	    npm install -g node-pre-gyp
+            echo "Directory 'node_modules' exists. Running 'npm rebuild'"
+            npm rebuild --production --unsafe-perm
+          fi
+        fi
+      else
+        echo "WARN: 'npm' was not on the path. Dependencies may be missing."
+      fi
+      ;;
+    copy)
+      # pass
+      ;;
+    npm-install)
+      echo 'Installing dependenencies from NPM'
+      npm install --production
+      ;;
+    *)
+      echo "WARN: Unexpected install strategy: $install_strategy"
+      echo 'WARN: Dependencies may be missing.'
+      ;;
+  esac
+}
+
+dependency_install '{{ node_deb_package_name }}'
+
+if [[ "$init_type" != 'none' ]]; then
+  add_group '{{ node_deb_group }}' ''
+  add_user '{{ node_deb_user }}' '' '{{ node_deb_group }}' '{{ node_deb_user }} user-daemon' '/bin/false'
+
+  mkdir -p '/var/log/signalk-server'
+  chown -R '{{ node_deb_user }}:{{ node_deb_group }}' '/var/log/signalk-server'
+
+  mkdir -p '/etc/signalk-server'
+
+  chown -R '{{ node_deb_user }}:{{ node_deb_group }}' '/etc/signalk-server'
+
+
+  start_service '{{ node_deb_package_name }}'
+fi


### PR DESCRIPTION
This pull request sets some build stages in Travis that use the npm package node-deb to build a Debian package, which is then pushed to packagecloud.io. 

There are 2 build stages.

1) The first builds all branches, with a packagename of "signalk-server-$BRANCH"(including master). So on every commit to every branch you get a package to test with. 

2) The second stage builds the main "signalk-server" package. This happens only on master branch, and only when the commit is tagged with a tag starting in "v[0-9]". 

There are 2 deploy stages on each build stage. This is only because of the different distributions (debian/raspbian). 

Note, that due to a few dependencies (bcrypt and mdns I think) build-essential is a dependency, and during the package install "npm install" is run to build them. If the package is popular enough it's possible that we could look into pre-compiling them, would need to see how to cross compile for arm though.

Regarding packagecloud, I have an account with the name "SignalK" that I got the opensource plan on. I can add collaborators, or I can look to transfer it over to someone else.