### PR TITLE
chore: replace bcrypt with bcryptjs

### DIFF
--- a/lib/tokensecurity.js
+++ b/lib/tokensecurity.js
@@ -20,7 +20,7 @@ const jwt = require('jsonwebtoken')
 const _ = require('lodash')
 const fs = require('fs')
 const path = require('path')
-const bcrypt = require('bcrypt')
+const bcrypt = require('bcryptjs')
 const getSourceId = require('@signalk/signalk-schema').getSourceId
 
 const CONFIG_PLUGINID = 'sk-simple-token-security-config'

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@signalk/simplegauges": "^1.0.1",
     "@signalk/zones": "^1.0.0",
     "baconjs": "^1.0.1",
+    "bcryptjs": "^2.4.3",
     "body-parser": "^1.14.1",
     "canboatjs": "0.0.11",
     "colors": "^1.1.2",
@@ -144,7 +145,6 @@
     "request-promise": "^4.1.1"
   },
   "optionalDependencies": {
-    "bcrypt": "^1.0.3",
     "mdns": "^2.3.4"
   }
 }


### PR DESCRIPTION
Use js-only bcryptjs instead of bcrypt with native
bindings.