### PR TITLE
fix: reorganise nmea0183 passing

### DIFF
--- a/lib/pipedproviders.js
+++ b/lib/pipedproviders.js
@@ -18,7 +18,7 @@ const deep = require('deep-get-set')
 const DevNull = require('dev-null-stream')
 
 module.exports = function (app) {
-  function createPipedProvider (providerConfig, nmea0183Listener) {
+  function createPipedProvider (providerConfig) {
     var result = {
       id: providerConfig.id,
       pipeElements: providerConfig.pipeElements.reduce((result, config) => {
@@ -28,12 +28,6 @@ module.exports = function (app) {
         return result
       }, [])
     }
-
-    result.pipeElements.forEach(function (pipeElement) {
-      if (typeof pipeElement.on === 'function') {
-        pipeElement.on('nmea0183', nmea0183Listener)
-      }
-    })
 
     for (var i = result.pipeElements.length - 2; i >= 0; i--) {
       result.pipeElements[i].pipe(result.pipeElements[i + 1])
@@ -66,13 +60,10 @@ module.exports = function (app) {
   }
 
   function startProviders () {
-    var nmea0183Listener = function (sentence) {
-      app.signalk.emit('nmea0183', sentence)
-    }
     if (app.config.settings.pipedProviders) {
       piped = app.config.settings.pipedProviders.reduce((result, config) => {
         if (typeof config.enabled === 'undefined' || config.enabled) {
-          result.push(createPipedProvider(config, nmea0183Listener))
+          result.push(createPipedProvider(config))
         }
         return result
       }, [])

--- a/providers/nmea0183-signalk.js
+++ b/providers/nmea0183-signalk.js
@@ -41,7 +41,7 @@ function nmea0183ToSignalK (options) {
   this.parser = new Parser(options)
 
   this.parser.on('nmea0183', sentence => {
-    this.emit('nmea0183', sentence)
+    options.app.signalk.emit('nmea0183', sentence)
   })
 
   if (options.sentenceEvent) {

--- a/providers/simple.js
+++ b/providers/simple.js
@@ -94,13 +94,17 @@ const dataTypeMapping = {
     options.subOptions.type != 'wss' && options.subOptions.type != 'ws'
       ? [new FromJson(options.subOptions)]
       : [],
-  NMEA0183: options => [
-    new Throttle({
-      rate: options.subOptions.throttleRate || 1000,
-      app: options.app
-    }),
-    new nmea0183_signalk(options.subOptions)
-  ],
+  NMEA0183: options => {
+    const result = [new nmea0183_signalk(options.subOptions)]
+    if (options.type === 'FileStream') {
+      result.unshift(
+        new Throttle({
+          rate: options.subOptions.throttleRate || 1000
+        })
+      )
+    }
+    return result
+  },
   NMEA2000: options => {
     const result = [new N2kAnalyzer(options.subOptions)]
     if (options.type === 'FileStream') {


### PR DESCRIPTION
Simple provider created from the admin ui was not
passing nmea0183 events at all, because the logic was in
pipedprovider pipeline construction. Providers can send
events directly because they have access to the app
and app.signalk, so use that to send nmea0183 events
from the provider and remove the related logic
from pipedprovider pipeline construction.