### PR TITLE
Fix Admin UI errors in Firefox

### DIFF
--- a/admin-ui/src/views/Security.js
+++ b/admin-ui/src/views/Security.js
@@ -112,7 +112,6 @@ class Security extends Component {
       return
     }
 
-    console.log(`password: ${this.state.selectedUser.password}`)
     if (this.state.selectedUser.password) {
       if (
         this.state.selectedUser.password !=

--- a/admin-ui/src/views/Security.js
+++ b/admin-ui/src/views/Security.js
@@ -187,7 +187,7 @@ class Security extends Component {
       })
   }
 
-  userClicked (event, user, index) {
+  userClicked (user, index) {
     console.log(JSON.stringify(user))
     this.setState(
       {
@@ -296,7 +296,6 @@ class Security extends Component {
                           key={user.userId}
                           onClick={this.userClicked.bind(
                             this,
-                            event,
                             user,
                             index
                           )}

--- a/admin-ui/src/views/Security.js
+++ b/admin-ui/src/views/Security.js
@@ -167,10 +167,6 @@ class Security extends Component {
       })
   }
 
-  changePassword (userId) {
-    console.log(userId)
-  }
-
   handleSaveConfig () {
     var payload = {
       allow_readonly: this.state.allow_readonly,

--- a/admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -256,6 +256,7 @@ class ProvidersConfiguration extends Component {
                     id='json'
                     rows='20'
                     value={this.state.selectedProvider.json}
+                    readOnly='true'
                   />
                 )}
               </CardBody>

--- a/admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -163,7 +163,7 @@ class ProvidersConfiguration extends Component {
       })
   }
 
-  providerClicked (event, provider, index) {
+  providerClicked (provider, index) {
     this.setState(
       {
         selectedProvider: {
@@ -206,7 +206,6 @@ class ProvidersConfiguration extends Component {
                     <tr
                       onClick={this.providerClicked.bind(
                         this,
-                        event,
                         provider,
                         index
                       )}


### PR DESCRIPTION
Security and ProviderConfiguration panels were erroring on Firefox because of undefined, unneede variables. 

Fixes also a React complaint about readonly JSON field, removes an unused function and removes console.logging the password when you set it.

Fixes #486 