### PR TITLE
fix: canboatjs interface option not getting passed to provider

### DIFF
--- a/providers/simple.js
+++ b/providers/simple.js
@@ -138,7 +138,7 @@ function nmea2000input (subOptions) {
   } else if (subOptions.type === 'canbus-canboatjs') {
     return [
       new require('./canbus')({
-        canDevice: subOptions.device,
+        canDevice: subOptions.interface,
         app: subOptions.app
       })
     ]


### PR DESCRIPTION
When the canbus interface is specified in the admin ui, it is ignored and the default is used.

Fixes #489