### PR TITLE
feature: allow plugins to be seamlessly moved under @signalk

### DIFF
--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -208,6 +208,16 @@ module.exports = function (app) {
       debug: require('debug')(pluginName)
     })
     const plugin = require(path.join(location, pluginName))(appCopy)
+
+    if (app.pluginsMap[plugin.id]) {
+      console.log(
+        `WARNING: found multiple copies of plugin with id ${
+          plugin.id
+        } at ${location} and ${app.pluginsMap[plugin.id].packageLocation}`
+      )
+      return
+    }
+
     appCopy.handleMessage = handleMessageWrapper(app, plugin.id)
     appCopy.savePluginOptions = (options, cb) => {
       savePluginOptions(plugin.id, options, cb)
@@ -236,7 +246,7 @@ module.exports = function (app) {
       })
     }
     if (options && options.enabled) {
-      debug('Starting plugin ' + pluginName)
+      debug('Starting plugin %s from %s', pluginName, location)
       plugin.start(getPluginOptions(plugin.id).configuration, restart)
       debug('Started plugin ' + pluginName)
     }
@@ -246,6 +256,7 @@ module.exports = function (app) {
 
     plugin.version = metadata.version
     plugin.packageName = metadata.name
+    plugin.packageLocation = location
 
     var router = express.Router()
     router.get('/', (req, res) => {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -23,23 +23,27 @@ const path = require('path')
 function modulesWithKeyword (app, keyword) {
   var res = []
 
+  var prioritize = (a, b) => {
+    return a.module.startsWith('@signalk') ? -1 : 1
+  }
+
   if (app.config.configPath != app.config.appPath) {
     var modulesPath = path.join(app.config.configPath, 'node_modules')
 
     if (fs.existsSync(modulesPath)) {
-      res = findModulesInDir(modulesPath + '/', keyword)
+      res = findModulesInDir(modulesPath + '/', keyword).sort(prioritize)
     }
   }
 
   res.push.apply(
     res,
-    findModulesInDir(__dirname + '/../node_modules/', keyword).filter(
-      module => {
+    findModulesInDir(__dirname + '/../node_modules/', keyword)
+      .filter(module => {
         return !res.find(m => {
           return m.module == module.module
         })
-      }
-    )
+      })
+      .sort(prioritize)
   )
 
   return res


### PR DESCRIPTION

Makes so we prioritize loading plugins under @signalk and that we don't load multiple versions of the same plugin from different locations.
