### PR TITLE
Add buildFetchAction() to slim admin-ui actions code.

### DIFF
--- a/admin-ui/src/actions.js
+++ b/admin-ui/src/actions.js
@@ -111,60 +111,21 @@ export function restart () {
   }
 }
 
-export function fetchLoginStatus (dispatch) {
-  authFetch(`/loginStatus`)
+export const buildFetchAction = (endpoint, type) => dispatch =>
+  authFetch(endpoint)
     .then(response => response.json())
     .then(data =>
       dispatch({
-        type: 'RECEIVE_LOGIN_STATUS',
+        type,
         data
       })
     )
-}
 
-export function fetchPlugins (dispatch) {
-  authFetch(`/plugins`)
-    .then(response => response.json())
-    .then(plugins =>
-      dispatch({
-        type: 'RECEIVE_PLUGIN_LIST',
-        plugins
-      })
-    )
-}
-
-export function fetchWebapps (dispatch) {
-  authFetch(`/webapps`)
-    .then(response => response.json())
-    .then(webapps =>
-      dispatch({
-        type: 'RECEIVE_WEBAPPS_LIST',
-        webapps
-      })
-    )
-}
-
-export function fetchApps (dispatch) {
-  authFetch(`/appstore/available`)
-    .then(response => response.json())
-    .then(data =>
-      dispatch({
-        type: 'RECEIVE_APPSTORE_LIST',
-        data
-      })
-    )
-}
-
-export function fetchServerSpecification(dispatch) {
-  authFetch(`/signalk`)
-    .then(response => response.json())
-    .then(data =>
-      dispatch({
-        type: 'RECEIVE_SERVER_SPEC',
-        data
-      })
-    )
-}
+export const fetchLoginStatus = buildFetchAction('/loginStatus', 'RECEIVE_LOGIN_STATUS')
+export const fetchPlugins = buildFetchAction('/plugins', 'RECEIVE_PLUGIN_LIST')
+export const fetchWebapps = buildFetchAction('/webapps', 'RECEIVE_WEBAPPS_LIST')
+export const fetchApps = buildFetchAction('/appstore/available', 'RECEIVE_APPSTORE_LIST')
+export const fetchServerSpecification = buildFetchAction('/signalk', 'RECEIVE_SERVER_SPEC')
 
 export function fetchAllData (dispatch) {
   fetchPlugins(dispatch)

--- a/admin-ui/src/actions.js
+++ b/admin-ui/src/actions.js
@@ -111,6 +111,7 @@ export function restart () {
   }
 }
 
+// Build actions that perform a basic authFetch to the backend
 export const buildFetchAction = (endpoint, type) => dispatch =>
   authFetch(endpoint)
     .then(response => response.json())

--- a/admin-ui/src/actions.js
+++ b/admin-ui/src/actions.js
@@ -111,7 +111,7 @@ export function restart () {
   }
 }
 
-// Build actions that perform a basic authFetch to the backend
+// Build actions that perform a basic authFetch to the backend. Pull #514.
 export const buildFetchAction = (endpoint, type) => dispatch =>
   authFetch(endpoint)
     .then(response => response.json())

--- a/admin-ui/src/index.js
+++ b/admin-ui/src/index.js
@@ -42,13 +42,13 @@ let store = createStore(
     if (action.type === 'RECEIVE_PLUGIN_LIST') {
       return {
         ...state,
-        plugins: action.plugins
+        plugins: action.data
       }
     }
     if (action.type === 'RECEIVE_WEBAPPS_LIST') {
       return {
         ...state,
-        webapps: action.webapps
+        webapps: action.data
       }
     }
     if (


### PR DESCRIPTION
In looking into #449 I noticed some repeating code that could be slimed down with a generator function. The new `buildFetchAction()` builds actions that perform a basic `authFetch` to the backend. Having a generator function like this helps reduce inconsistencies and bloat. I noticed in the redux reducer sometimes the action payload is on a prop specific to the action like `plugins` or `webapps`. Other times it is more general like `data`. The builder function makes the payload prop name `data` every time. It might be worth switching to `payload` to be more inline with standards like [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action)?

If cleanup like this is welcome I'm happy to continue making small, hopefully helpful cleanup changes.