### PR TITLE
chore: use s/console.log/debug in lib/modules

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -69,7 +69,7 @@ function findModulesInDir (dir, keyword) {
         try {
           metadata = require(dir + filename + '/package.json')
         } catch (err) {
-          console.log(err)
+          debug(err)
         }
         if (
           metadata &&


### PR DESCRIPTION
If there is an issue with loading a package.json a debug log should be sufficient. I think console.log is overkill in this case.