### PR TITLE
fix: deltacache is building the full tree when a path that does not exist is requested

### DIFF
--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -81,22 +81,24 @@ DeltaCache.prototype.pruneContexts = function (seconds) {
   }
 }
 DeltaCache.prototype.buildFull = function (user, path) {
-  var signalk = new FullSignalK(
-    this.app.selfId,
-    this.app.selfType,
-    JSON.parse(JSON.stringify(this.defaults))
-  )
-
-  const leaf = getLeafObject(this.cache, path, false, true)
+  const leaf = getLeafObject(this.cache, path, false, false)
   if (leaf) {
+    var signalk = new FullSignalK(
+      this.app.selfId,
+      this.app.selfType,
+      JSON.parse(JSON.stringify(this.defaults))
+    )
+
     const deltas = findDeltas(leaf).map(toDelta)
     const secFilter = this.app.securityStrategy.shouldFilterDeltas()
       ? delta => this.app.securityStrategy.filterReadDelta(user, delta)
       : delta => true
     deltas.filter(secFilter).forEach(signalk.addDelta.bind(signalk))
-  }
 
-  return signalk.retrieve()
+    return signalk.retrieve()
+  } else {
+    return null
+  }
 }
 
 DeltaCache.prototype.getCachedDeltas = function (user, contextFilter, key) {

--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -81,24 +81,22 @@ DeltaCache.prototype.pruneContexts = function (seconds) {
   }
 }
 DeltaCache.prototype.buildFull = function (user, path) {
+  var signalk = new FullSignalK(
+    this.app.selfId,
+    this.app.selfType,
+    JSON.parse(JSON.stringify(this.defaults))
+  )
+
   const leaf = getLeafObject(this.cache, path, false, false)
   if (leaf) {
-    var signalk = new FullSignalK(
-      this.app.selfId,
-      this.app.selfType,
-      JSON.parse(JSON.stringify(this.defaults))
-    )
-
     const deltas = findDeltas(leaf).map(toDelta)
     const secFilter = this.app.securityStrategy.shouldFilterDeltas()
       ? delta => this.app.securityStrategy.filterReadDelta(user, delta)
       : delta => true
     deltas.filter(secFilter).forEach(signalk.addDelta.bind(signalk))
-
-    return signalk.retrieve()
-  } else {
-    return null
   }
+
+  return signalk.retrieve()
 }
 
 DeltaCache.prototype.getCachedDeltas = function (user, contextFilter, key) {


### PR DESCRIPTION

This was causing big performance issues because the full tree was being built when a request for /resources/charts is made.