### PR TITLE
refactor: prefer Date.now()

### DIFF
--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -59,7 +59,7 @@ DeltaCache.prototype.onValue = function (msg) {
       leaf[key][source] = msg
     })
   }
-  this.lastModifieds[msg.context] = new Date().getTime()
+  this.lastModifieds[msg.context] = Date.now()
 }
 
 DeltaCache.prototype.deleteContext = function (contextKey) {
@@ -72,7 +72,7 @@ DeltaCache.prototype.deleteContext = function (contextKey) {
 
 DeltaCache.prototype.pruneContexts = function (seconds) {
   debug('pruning contexts...')
-  var threshold = new Date().getTime() - seconds * 1000
+  var threshold = Date.now() - seconds * 1000
   for (let contextKey in this.lastModifieds) {
     if (this.lastModifieds[contextKey] < threshold) {
       this.deleteContext(contextKey)

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -44,7 +44,7 @@ module.exports = (app, discriminator, logdir) => {
   return msg => {
     try {
       logger.write(
-        new Date().getTime() +
+        Date.now() +
           ';' +
           discriminator +
           ';' +

--- a/lib/tokensecurity.js
+++ b/lib/tokensecurity.js
@@ -448,7 +448,7 @@ module.exports = function (app, config) {
 
   strategy.verifyWS = function (spark) {
     if (!spark.lastTokenVerify) {
-      spark.lastTokenVerify = new Date()
+      spark.lastTokenVerify = Date.now()
       return
     }
 
@@ -456,7 +456,7 @@ module.exports = function (app, config) {
       return
     }
 
-    var now = new Date()
+    var now = Date.now()
     if (now - spark.lastTokenVerify > 60 * 1000) {
       debug('verify token')
       spark.lastTokenVerify = now

--- a/providers/timestamp-throttle.js
+++ b/providers/timestamp-throttle.js
@@ -42,8 +42,7 @@ TimestampThrottle.prototype._transform = function (msg, encoding, done) {
     this.offsetMillis = new Date().getTime() - msgMillis
   }
   this.lastMsgMillis = msgMillis
-  var millisToCorrectSendTime =
-    msgMillis - new Date().getTime() + this.offsetMillis
+  var millisToCorrectSendTime = msgMillis - Date.now() + this.offsetMillis
   if (millisToCorrectSendTime <= 0) {
     this.push(msg)
     done()


### PR DESCRIPTION
Date.now() is more performant than new Date().getTime().