### PR TITLE
[WIP] refactor: remove in memory full tree

### DIFF
--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -99,6 +99,15 @@ DeltaCache.prototype.buildFull = function (user, path) {
   return signalk.retrieve()
 }
 
+DeltaCache.prototype.getPath = function (path) {
+  let parts = path.length > 0 ? path.split('.') : []
+  if (parts.length > 1 && parts[1] === 'self') {
+    parts[1] = this.app.selfId
+  }
+  let full = this.buildFull(null, parts)
+  return full && _.get(full, parts.join('.'))
+}
+
 DeltaCache.prototype.getCachedDeltas = function (user, contextFilter, key) {
   var contexts = []
   _.keys(this.cache).forEach(type => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,8 @@ function Server(opts) {
   require('./serverroutes')(app, saveSecurityConfig, getSecurityConfig)
   require('./put').start(app)
 
-  app.signalk = new FullSignalK(app.selfId, app.selfType, app.config.defaults)
+  //app.signalk = new FullSignalK(app.selfId, app.selfType, app.config.defaults)
+  app.signalk = new FakeFullSignalK()
 
   app.handleMessage = function(providerId, data) {
     if (data && data.updates) {
@@ -84,6 +85,14 @@ function Server(opts) {
     }
   }
 
+  app.getSelfPath = function(path) {
+    return app.deltaCache.getPath('vessels.self.' + path)
+  }
+
+  app.getPath = function(path) {
+    return app.deltaCache.getPath(path)
+  }
+
   app.webapps = []
 
   app.streambundle = new StreamBundle(app.selfId)
@@ -100,9 +109,6 @@ Server.prototype.start = function() {
 
   this.app.intervals = []
 
-  this.app.intervals.push(
-    setInterval(app.signalk.pruneContexts.bind(app.signalk, 60 * 60), 60 * 1000)
-  )
   this.app.intervals.push(
     setInterval(
       app.deltaCache.pruneContexts.bind(app.deltaCache, 60 * 60),
@@ -354,4 +360,12 @@ function getSecurityConfig(app) {
   } catch (e) {
     return {}
   }
+}
+
+function FakeFullSignalK() {}
+
+require('util').inherits(FakeFullSignalK, require('events').EventEmitter)
+
+FakeFullSignalK.prototype.addDelta = function(delta) {
+  this.emit('delta', delta)
 }

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -157,14 +157,6 @@ module.exports = function (app) {
     }
   }
 
-  function getSelfPath (path) {
-    return _.get(app.signalk.self, path)
-  }
-
-  function getPath (path) {
-    return _.get(app.signalk.retrieve(), path)
-  }
-
   function putSelfPath (path, value) {
     return _putPath(app, `vessels.self.${path}`, { value: value })
   }
@@ -199,8 +191,6 @@ module.exports = function (app) {
 
   function doRegisterPlugin (app, pluginName, metadata, location) {
     const appCopy = _.assign({}, app, {
-      getSelfPath,
-      getPath,
       putSelfPath,
       putPath,
       error: msg => {

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -35,7 +35,6 @@ module.exports = function (app) {
 
       app.get(apiPathPrefix + '*', function (req, res, next) {
         var path = String(req.path).replace(apiPathPrefix, '')
-        var data = app.signalk.retrieve()
 
         if (path === 'self') {
           return res.json(`vessels.${app.selfId}`)

--- a/lib/subscriptionmanager.js
+++ b/lib/subscriptionmanager.js
@@ -209,12 +209,12 @@ function contextMatcher (selfContext, app, subscribeCommand, errorCallback) {
   return x => true
 }
 
-
 function checkPosition (app, context, normalizedDeltaData) {
-  var vessel = _.get(app.signalk.root, normalizedDeltaData.context)
-  var position = _.get(vessel, 'navigation.position')
+  let position = app.getPath(
+    `vessels.${normalizedDeltaData.context}.navigation.position`
+  )
 
-  var subsPosition = _.get(context, 'position')
+  let subsPosition = _.get(context, 'position')
   if (
     position &&
     subsPosition &&

--- a/lib/tokensecurity.js
+++ b/lib/tokensecurity.js
@@ -418,7 +418,12 @@ module.exports = function (app, config) {
 
   strategy.filterReadDelta = (user, delta) => {
     var configuration = getConfiguration()
-    if (delta.updates && configuration.acls && configuration.acls.length) {
+    if (
+      user &&
+      delta.updates &&
+      configuration.acls &&
+      configuration.acls.length
+    ) {
       var context =
         delta.context === app.selfContext ? 'vessels.self' : delta.context
 


### PR DESCRIPTION

I just updated my plugins to remove direct use of the full tree. We should probably give people time to update their plugins before we release this.

We also need to get other plugin developers to remove full tree usage.

I will be finding the plugins that do and will reach out to the developers...