### PR TITLE
feature: add OVERRIDEENABLEPLUGINS, tweak plugin settings reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Environment variables
 - `TCPSTREAMPORT` override the port for the Signal K Streaming (deltas) over TCP
 - `TCPSTREAMADDRESS` override the address the Signal K Stream (deltas) over TCP is listening on
 - `DISABLEPLUGINS` disable all plugins so that they can not be enabled
+- `DEFAULTENABLEDPLUGINS` a comma separated list of plugin ids that are overridden to be enabled by default if no setttings exist. lower preference than `DISABLEPLUGINS`
 - `SECURITYSTRATEGY` override the security strategy module name
 
 

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -27,6 +27,10 @@ const { getModulePublic } = require('../config/get')
 // #521 Returns path to load plugin-config assets.
 const getPluginConfigPublic = getModulePublic('@signalk/plugin-config')
 
+const DEFAULT_ENABLED_PLUGINS = process.env['DEFAULTENABLEDPLUGINS']
+  ? process.env['DEFAULTENABLEDPLUGINS'].split(',')
+  : []
+
 module.exports = function (app) {
   return {
     start: function () {
@@ -100,23 +104,29 @@ module.exports = function (app) {
   }
 
   function getPluginOptions (id) {
+    const optionsAsString = '{}'
     try {
-      const optionsAsString = fs.readFileSync(pathForPluginId(id), 'utf8')
-      try {
-        const options = JSON.parse(optionsAsString)
-        if (process.env.DISABLEPLUGINS) {
-          debug('Plugins disabled by configuration')
-          options.enabled = false
-        }
-        debug(optionsAsString)
-        return options
-      } catch (e) {
-        console.error('Could not parse JSON options:' + optionsAsString)
-        return {}
-      }
+      fs.readFileSync(pathForPluginId(id), 'utf8')
     } catch (e) {
       debug(
         'Could not find options for plugin ' + id + ', returning empty options'
+      )
+    }
+    try {
+      const options = JSON.parse(optionsAsString)
+      if (optionsAsString === '{}' && DEFAULT_ENABLED_PLUGINS.includes(id)) {
+        debug('Override enable for plugin ' + id)
+        options.enabled = true
+      }
+      if (process.env.DISABLEPLUGINS) {
+        debug('Plugins disabled by configuration')
+        options.enabled = false
+      }
+      debug(optionsAsString)
+      return options
+    } catch (e) {
+      console.error(
+        'Could not parse JSON options:' + e.message + ' ' + optionsAsString
       )
       return {}
     }


### PR DESCRIPTION
Add OVERRIDEENABLEPLUGINS environment option and tweak loading
of plugin settings so that we can override even if there
are no settings available.

This way we can enable some plugins by default for example in Heroku or in a preinstalled setup.