### PR TITLE
fix: show dual plugin/webapps as one line in the App store listings

### DIFF
--- a/lib/interfaces/appstore.js
+++ b/lib/interfaces/appstore.js
@@ -212,26 +212,32 @@ module.exports = function (app) {
 
       if (moduleInstallQueue.find(p => p.name == name)) {
         pluginInfo.isWaiting = true
-        result.installing.push(pluginInfo)
+        addIfNotDuplicate(result.installing, pluginInfo)
       } else if (modulesInstalledSinceStartup[name]) {
         if (moduleInstalling && moduleInstalling.name == name) {
           pluginInfo.isInstalling = true
         } else if (modulesInstalledSinceStartup[name].code != 0) {
           pluginInfo.installFailed = true
         }
-        result.installing.push(pluginInfo)
+        addIfNotDuplicate(result.installing, pluginInfo)
       } else if (installedModule) {
         if (compareVersions(version, installedModule.version) > 0) {
-          result.updates.push(pluginInfo)
+          addIfNotDuplicate(result.updates, pluginInfo)
         } else {
-          result.installed.push(pluginInfo)
+          addIfNotDuplicate(result.installed, pluginInfo)
         }
       } else {
-        result.available.push(pluginInfo)
+        addIfNotDuplicate(result.available, pluginInfo)
       }
 
       return result
     })
+  }
+
+  function addIfNotDuplicate (theArray, moduleInfo) {
+    if (!theArray.find(p => p.name === moduleInfo.name)) {
+      theArray.push(moduleInfo)
+    }
   }
 
   function makeSection (title, modules, existing, pathPrefix) {


### PR DESCRIPTION
Plugins that are also webapps were shown two times in
the appstore list. This commit change the behavior so
that they are listed only once.