### PR TITLE
feature: make webapps list multiple columns, change text order

### DIFF
--- a/packages/server-admin-ui/src/views/Webapps/Webapp.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapp.js
@@ -62,7 +62,7 @@ class Widget02 extends Component {
     )
 
     const lead = { style: 'h5 mb-0', color: color, classes: '' }
-    lead.classes = classNames(lead.style, 'text-' + card.color, padding.lead)
+    lead.classes = classNames(lead.style, 'text-' + card.color, padding.lead, 'text-capitalize')
 
     const blockIcon = function (icon) {
       const classes = classNames(
@@ -96,7 +96,7 @@ class Widget02 extends Component {
           <CardBody className={card.classes} {...attributes}>
             {blockIcon(card.icon)}
             <div className={lead.classes}>{header}</div>
-            <div className='text-muted text-uppercase font-weight-bold font-xs'>
+            <div className='text-muted font-xs'>
               {mainText}
             </div>
           </CardBody>

--- a/packages/server-admin-ui/src/views/Webapps/Webapps.js
+++ b/packages/server-admin-ui/src/views/Webapps/Webapps.js
@@ -1,22 +1,25 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
+import { Col } from 'reactstrap'
 
 import Webapp from './Webapp'
 
 class Webapps extends Component {
   render () {
     return (
-      <div className='animated fadeIn'>
+      <div className='row animated fadeIn'>
         {this.props.webapps.map(webappInfo => {
           return (
+            <Col xs='12' md='12' lg='6' xl='4'>
             <Webapp
               key={webappInfo.name}
-              header={webappInfo.description}
-              mainText={`${webappInfo.name} ${webappInfo.version}`}
+              header={webappInfo.name}
+              mainText={webappInfo.description}
               url={`/${webappInfo.name}`}
               icon='fa fa-external-link'
               color='primary'
             />
+            </Col>
           )
         })}
       </div>


### PR DESCRIPTION
Make webapps list in the admin ui responsive & multicolumn. Change
the texts so that the short name is the title and description more
muted. Remove version - it is available in the App store.
Previously:
![image](https://user-images.githubusercontent.com/1049678/40937838-9aaf5494-6848-11e8-996a-116576a431f1.png)

Now:
![image](https://user-images.githubusercontent.com/1049678/40937807-83f6e24e-6848-11e8-9e91-be813c7d8115.png)
