### PR TITLE
Fix: Allow running a SignalK Server with a simple include

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -21,32 +21,19 @@ const agent = require('superagent-promise')(require('superagent'), Promise)
 const path = require('path')
 
 function modulesWithKeyword (app, keyword) {
-  var res = []
-
-  var prioritize = (a, b) => {
-    return a.module.startsWith('@signalk') ? -1 : 1
-  }
-
+  let modules = new Set()
+  // look in configPath for modules
   if (app.config.configPath != app.config.appPath) {
-    var modulesPath = path.join(app.config.configPath, 'node_modules')
-
-    if (fs.existsSync(modulesPath)) {
-      res = findModulesInDir(modulesPath + '/', keyword).sort(prioritize)
-    }
+    let modulesPath = path.join(app.config.configPath, 'node_modules/')
+    if (fs.existsSync(modulesPath)) { findModulesInDir(modulesPath, keyword).forEach(m => modules.add(m)) }
   }
+  // look in working directory for modules
+  let workingPath = path.join(__dirname, '../node_modules/')
+  if (fs.existsSync(workingPath)) { findModulesInDir(workingPath, keyword).forEach(m => modules.add(m)) }
 
-  res.push.apply(
-    res,
-    findModulesInDir(path.join(app.config.configPath, 'node_modules/'), keyword)
-      .filter(module => {
-        return !res.find(m => {
-          return m.module == module.module
-        })
-      })
-      .sort(prioritize)
+  return Array.from(modules).sort(
+    (a, b) => (a.module.startsWith('@signalk') ? -1 : 1)
   )
-
-  return res
 }
 
 function findModulesInDir (dir, keyword) {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -37,7 +37,7 @@ function modulesWithKeyword (app, keyword) {
 
   res.push.apply(
     res,
-    findModulesInDir(__dirname + '/../node_modules/', keyword)
+    findModulesInDir(path.join(app.config.configPath, 'node_modules/'), keyword)
       .filter(module => {
         return !res.find(m => {
           return m.module == module.module


### PR DESCRIPTION
#548 Changed the _dirname path to app.config.configPath so that users would be able to set their own configurations. We are now able to use a .env file to set up our own configurations and just npm install signalk and use it as a dependency. This allows for a more robust and flexible use of signalk.