### PR TITLE
feature: add per plugin config get route

### DIFF
--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -309,6 +309,10 @@ module.exports = function (app) {
       })
     })
 
+    router.get('/config', (req, res) => {
+      res.json(getPluginOptions(plugin.id))
+    })
+
     if (typeof plugin.registerWithRouter !== 'undefined') {
       plugin.registerWithRouter(router)
     }


### PR DESCRIPTION
If a plugin is a web app that needs access to the configuration
data it should be able to retrieve just its own config,
not the configs for all the plugins, which was previously
the case.