### PR TITLE
fix: /sources in deltaCache full build

### DIFF
--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -84,7 +84,12 @@ DeltaCache.prototype.buildFull = function (user, path) {
     JSON.parse(JSON.stringify(this.defaults))
   )
 
-  const leaf = getLeafObject(this.cache, path, false, false)
+  const leaf = getLeafObject(
+    this.cache,
+    pathToProcessForFull(path),
+    false,
+    false
+  )
   if (leaf) {
     const deltas = findDeltas(leaf).map(toDelta)
     const secFilter = this.app.securityStrategy.shouldFilterDeltas()
@@ -94,6 +99,13 @@ DeltaCache.prototype.buildFull = function (user, path) {
   }
 
   return signalk.retrieve()
+}
+
+function pathToProcessForFull (pathArray) {
+  if (pathArray.length > 0 && pathArray[0] === 'sources') {
+    return []
+  }
+  return pathArray
 }
 
 DeltaCache.prototype.getCachedDeltas = function (user, contextFilter, key) {

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -123,4 +123,14 @@ describe('deltacache', () => {
       })
     })
   })
+
+  it('returns /sources correctly', function () {
+    return serverP.then(server => {
+      return deltaP.then(() => {
+        var fullTree = server.app.deltaCache.buildFull(null, ['sources'])
+        fullTree.should.be.validSignalK
+        fullTree.sources.should.deep.equal({ deltaFromHttp: {} })
+      })
+    })
+  })
 })


### PR DESCRIPTION
If the request is under /sources we need to build the full
based on all deltas so that the full /sources structure gets
built.

Fixes #584.