### PR TITLE
refactor: Allow constructor to set `configPath`. Related code cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The http port can be configured separately with environment variable `PORT`. You
 
 Storing Configuration Outside The Server Install Directory
 ==========================================================
-You can store configuration like the settings file, plugin cofiguration and defaults.js in a directory outside of the server install using the `-c` option (or the `SIGNALK_NODE_CONDFIG_DIR` env variable).
+You can store configuration like the settings file, plugin cofiguration and defaults.js in a directory outside of the server install using the `-c` option (or the `SIGNALK_NODE_CONFIG_DIR` env variable).
 
 By default, the server will look for a `settings.json` and a `defaults.json` file in the given directory.
 
@@ -103,7 +103,7 @@ In this case, the server would look for the settings file at `/usr/local/etc/nod
 Environment variables
 ---------------------
 - `SIGNALK_NODE_SETTINGS` override the path to the settings file
-- `SIGNALK_NODE_CONDFIG_DIR` override the path to find server configuration files
+- `SIGNALK_NODE_CONFIG_DIR` override the path to find server configuration files
 - `PORT` override the port for http/ws service
 - `SSLPORT` override the port for https/wss service. If defined activates ssl as forced, default protocol.
 - `EXTERNALPORT` the port used in /signalk response and Bonjour advertisement. Has precedence over configuration file.

--- a/SERVERPLUGINS.md
+++ b/SERVERPLUGINS.md
@@ -31,7 +31,7 @@ See [Ais Reporter](https://github.com/SignalK/aisreporter/issues) for an example
 
 ## Plugin configuration files
 
-A plugin's configuration data is saved at `SIGNALK_NODE_CONDFIG_DIR/plugin-config-data/<plugin-name>.json`. You can disable a plugin by removing its configuration file.
+A plugin's configuration data is saved at `SIGNALK_NODE_CONFIG_DIR/plugin-config-data/<plugin-name>.json`. You can disable a plugin by removing its configuration file.
 
 ## Logging
 

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -45,12 +45,8 @@ function load (app) {
   debug('appPath:' + config.appPath)
   setConfigDirectory(app)
   createConfigFiles(app)
-  if (_.isObject(app.config.settings)) {
-    debug('Using settings from constructor call, not reading defaults')
-  } else {
-    readSettingsFile(app)
-    setFullDefaults(app)
-  }
+  readSettingsFile(app)
+  setFullDefaults(app)
   setSelfSettings(app)
 
   if (app.argv['sample-nmea0183-data']) {
@@ -162,7 +158,7 @@ function readDefaultsFile (app) {
 }
 
 function setFullDefaults (app) {
-  if (app.config.settings.noFiles) return
+  if (!app.config.settings.loadFiles) return
   const defaultsPath = getDefaultsPath(app)
   app.config.settings.defaultsPath = defaultsPath
   try {
@@ -237,19 +233,27 @@ function setSelfSettings (app) {
 }
 
 function readSettingsFile (app) {
-  const settings = getSettingsFilename(app)
-  if (!app.argv.s && !fs.existsSync(settings)) {
-    console.log('Settings file does not exist, using empty settings')
-    app.config.settings = {}
+  if (!_.isObject(app.config.settings)) { app.config.settings = { loadFiles: true } }
+  const defaultSettings = {
+    interfaces: {},
+    pipedProviders: [],
+    filename: 'settings.json',
+    loadFiles: false
+  }
+  _.defaults(app.config.settings, defaultSettings)
+  const settingsFile = getSettingsFilename(app)
+  _.set(app.config.settings, 'filepath', settingsFile)
+  if (!app.config.settings.loadFiles) {
+    debug(
+      'Settings set in constructor call. Set `config.settings.loadFiles: true` to merge files.'
+    )
+    return
+  }
+  if (!fs.existsSync(settingsFile)) {
+    debug('Settings file does not exist.')
   } else {
-    debug('Using settings file: ' + settings)
-    app.config.settings = require(settings)
-  }
-  if (_.isUndefined(app.config.settings.pipedProviders)) {
-    app.config.settings.pipedProviders = []
-  }
-  if (_.isUndefined(app.config.settings.interfaces)) {
-    app.config.settings.interfaces = {}
+    debug('Adding settings defaults: ' + settingsFile)
+    app.config.settings = _.merge(require(settingsFile), app.config.settings)
   }
 }
 
@@ -265,8 +269,7 @@ function getSettingsFilename (app) {
     )
     return path.resolve(app.env.SIGNALK_NODE_SETTINGS)
   }
-
-  var settingsFile = app.argv.s || 'settings.json'
+  const settingsFile = app.argv.s || app.config.settings.filename
   return path.join(app.config.configPath, settingsFile)
 }
 

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -133,9 +133,9 @@ function createConfigFiles (app) {
 
 function setConfigDirectory (app) {
   const paths = _.at(app, [
-    'config.configPath',
     'env.SIGNALK_NODE_CONFIG_DIR',
     'env.SIGNALK_NODE_CONDFIG_DIR',
+    'config.configPath',
     'argv.c',
     'env.HOME',
     'config.appPath'
@@ -162,7 +162,9 @@ function readDefaultsFile (app) {
 }
 
 function setFullDefaults (app) {
+  if (app.config.settings.noFiles) return
   const defaultsPath = getDefaultsPath(app)
+  app.config.settings.defaultsPath = defaultsPath
   try {
     app.config.defaults = readDefaultsFile(app)
     debug(`Found defaults at ${defaultsPath.toString()}`)
@@ -257,11 +259,11 @@ function writeSettingsFile (app, settings, cb) {
 }
 
 function getSettingsFilename (app) {
-  if (process.env.SIGNALK_NODE_SETTINGS) {
+  if (app.env.SIGNALK_NODE_SETTINGS) {
     debug(
       'Settings filename was set in environment SIGNALK_NODE_SETTINGS, overriding all other options'
     )
-    return path.resolve(process.env.SIGNALK_NODE_SETTINGS)
+    return path.resolve(app.env.SIGNALK_NODE_SETTINGS)
   }
 
   var settingsFile = app.argv.s || 'settings.json'
@@ -309,5 +311,6 @@ module.exports = {
   load: load,
   writeSettingsFile: writeSettingsFile,
   writeDefaultsFile: writeDefaultsFile,
+  readSettingsFile: readSettingsFile,
   readDefaultsFile: readDefaultsFile
 }

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -44,6 +44,7 @@ function load (app) {
   config.appPath = config.appPath || path.normalize(__dirname + '/../../')
   debug('appPath:' + config.appPath)
   setConfigDirectory(app)
+  createConfigFiles(app)
   if (_.isObject(app.config.settings)) {
     debug('Using settings from constructor call, not reading defaults')
   } else {
@@ -104,23 +105,13 @@ function load (app) {
   require('./production')(app)
 }
 
-function setConfigDirectory (app) {
-  if (process.env.SIGNALK_NODE_CONDFIG_DIR) {
-    app.config.configPath = path.resolve(process.env.SIGNALK_NODE_CONDFIG_DIR)
-  } else if (process.env.SIGNALK_NODE_CONFIG_DIR) {
-    app.config.configPath = path.resolve(process.env.SIGNALK_NODE_CONFIG_DIR)
-  } else if (!app.argv.c && !app.argv.s && process.env.HOME) {
-    app.config.configPath = path.join(process.env.HOME, '.signalk')
-    console.log(`Using default configuration path: ${app.config.configPath}`)
-
+function createConfigFiles (app) {
+  if (app.config.configPath !== app.config.appPath) {
+    // Create config directory if not found.
     if (!fs.existsSync(app.config.configPath)) {
       fs.mkdirSync(app.config.configPath)
+      console.log(`Created config directory: ${app.config.configPath}`)
     }
-  } else {
-    app.config.configPath = app.argv.c || app.config.appPath
-  }
-
-  if (app.config.configPath != app.config.appPath) {
     var configPackage = path.join(app.config.configPath, 'package.json')
     if (!fs.existsSync(configPackage)) {
       fs.writeFileSync(
@@ -138,6 +129,21 @@ function setConfigDirectory (app) {
       }
     }
   }
+}
+
+function setConfigDirectory (app) {
+  const paths = _.at(app, [
+    'config.configPath',
+    'env.SIGNALK_NODE_CONFIG_DIR',
+    'env.SIGNALK_NODE_CONDFIG_DIR',
+    'argv.c',
+    'env.HOME',
+    'config.appPath'
+  ])
+  // Default to user home directory before using appPath as last resort.
+  paths[4] = paths[4] && path.join(paths[4], '.signalk')
+  app.config.configPath = path.resolve(_.find(paths))
+  debug('configPath: ' + app.config.configPath)
 }
 
 function getDefaultsPath (app) {
@@ -299,6 +305,7 @@ const pluginsPackageJsonTemplate = {
 }
 
 module.exports = {
+  setConfigDirectory: setConfigDirectory,
   load: load,
   writeSettingsFile: writeSettingsFile,
   writeDefaultsFile: writeDefaultsFile,

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -1,7 +1,9 @@
 const { expect } = require('chai')
-const { setConfigDirectory } = require('./config')
+const { load, readSettingsFile, setConfigDirectory } = require('./config')
+const { appPath } = require('./get')
 
 const app = {
+  argv: {},
   config: {
     appPath: '/var/node/signalk',
     configPath: '/data/signalk-config'
@@ -10,8 +12,8 @@ const app = {
     HOME: '/user/foo'
   }
 }
-setConfigDirectory(app)
 
+setConfigDirectory(app)
 describe('setConfigDirectory', () => {
   it('does not overwrite configPath if set previously.', () => {
     expect(app.config.configPath).to.equal('/data/signalk-config')
@@ -27,4 +29,55 @@ describe('setConfigDirectory', () => {
     setConfigDirectory(app)
     expect(app.config.configPath).to.equal('/var/node/signalk')
   })
+})
+
+describe('readSettingsFile', () => {
+  it('adds default config.settings', () => {
+    app.config.configPath = '/foo'
+    readSettingsFile(app)
+    expect(app.config.settings.filename).to.equal('settings.json')
+    expect(app.config.settings.filepath).to.equal('/foo/settings.json')
+  })
+  it('loads up a settings file', () => {
+    app.config.configPath = appPath
+    app.config.settings = {
+      loadFiles: true,
+      filename: 'settings/settings.json',
+      pipedProviders: [{}, { id: 'foo' }],
+      vessel: { foo: 'bar' }
+    }
+    readSettingsFile(app)
+    // console.log(app.config.settings)
+    expect(app.config.settings.pipedProviders[0].id).to.equal('nmeaFromFile')
+    expect(app.config.settings.pipedProviders[1].id).to.equal('foo')
+    expect(app.config.settings.vessel.name).to.equal('Volare')
+    expect(app.config.settings.vessel.foo).to.equal('bar')
+  })
+  it('ignores file if noFiles true', () => {
+    app.config.configPath = appPath
+    app.config.settings = {
+      filename: 'settings/settings.json',
+      pipedProviders: [{}, { id: 'foo' }],
+      vessel: { foo: 'bar' }
+    }
+    readSettingsFile(app)
+    // console.log(app.config.settings)
+    expect(app.config.settings.pipedProviders[0].id).to.equal(undefined)
+    expect(app.config.settings.pipedProviders[1].id).to.equal('foo')
+    expect(app.config.settings.vessel.name).to.equal(undefined)
+    expect(app.config.settings.vessel.foo).to.equal('bar')
+  })
+  it('SIGNALK_NODE_SETTINGS overrides', () => {
+    app.env.SIGNALK_NODE_SETTINGS = '/foo/sk/bar.json'
+    readSettingsFile(app)
+    expect(app.config.settings.filepath).to.equal('/foo/sk/bar.json')
+  })
+})
+describe('load', () => {
+  const app = { get: () => {} }
+  load(app)
+  it('Loads package.json and attaches name', () => {
+    expect(app.config.name).to.equal('signalk-server')
+  })
+  console.log(app)
 })

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -32,13 +32,13 @@ describe('setConfigDirectory', () => {
 })
 
 describe('readSettingsFile', () => {
-  it('adds default config.settings', () => {
+  it('Adds default config.settings', () => {
     app.config.configPath = '/foo'
     readSettingsFile(app)
     expect(app.config.settings.filename).to.equal('settings.json')
     expect(app.config.settings.filepath).to.equal('/foo/settings.json')
   })
-  it('loads up a settings file', () => {
+  it('Allows merging with file if loadFiles true', () => {
     app.config.configPath = appPath
     app.config.settings = {
       loadFiles: true,
@@ -53,7 +53,7 @@ describe('readSettingsFile', () => {
     expect(app.config.settings.vessel.name).to.equal('Volare')
     expect(app.config.settings.vessel.foo).to.equal('bar')
   })
-  it('ignores file if noFiles true', () => {
+  it('Does merge settings file if loadFiles undefined.', () => {
     app.config.configPath = appPath
     app.config.settings = {
       filename: 'settings/settings.json',

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -1,0 +1,30 @@
+const { expect } = require('chai')
+const { setConfigDirectory } = require('./config')
+
+const app = {
+  config: {
+    appPath: '/var/node/signalk',
+    configPath: '/data/signalk-config'
+  },
+  env: {
+    HOME: '/user/foo'
+  }
+}
+setConfigDirectory(app)
+
+describe('setConfigDirectory', () => {
+  it('does not overwrite configPath if set previously.', () => {
+    expect(app.config.configPath).to.equal('/data/signalk-config')
+  })
+  it('defaults to user dir', () => {
+    delete app.config.configPath
+    setConfigDirectory(app)
+    expect(app.config.configPath).to.equal('/user/foo/.signalk')
+  })
+  it('process dir is last', () => {
+    delete app.config.configPath
+    delete app.env.HOME
+    setConfigDirectory(app)
+    expect(app.config.configPath).to.equal('/var/node/signalk')
+  })
+})

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -9,7 +9,7 @@ const path = require('path')
 
 describe('Demo plugin ', () => {
   it('works', async () => {
-    process.env.SIGNALK_NODE_CONDFIG_DIR = require('path').join(
+    process.env.SIGNALK_NODE_CONFIG_DIR = require('path').join(
       __dirname,
       'plugin-test-config'
     )


### PR DESCRIPTION
In partial response to #548. Confusing that the documentation has SIGNALK_NODE_CON**D**FIG_DIR when the code says SIGNALK_NODE_CONFIG_DIR will override it. Included change in test/plugins.js too. 