### PR TITLE
feature: provide an API to playback and retrieve historical data

### DIFF
--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -78,24 +78,34 @@ DeltaCache.prototype.pruneContexts = function (seconds) {
   }
 }
 DeltaCache.prototype.buildFull = function (user, path) {
-  var signalk = new FullSignalK(
-    this.app.selfId,
-    this.app.selfType,
-    JSON.parse(JSON.stringify(this.defaults))
-  )
-
   const leaf = getLeafObject(
     this.cache,
     pathToProcessForFull(path),
     false,
     false
   )
+
+  let deltas
   if (leaf) {
-    const deltas = findDeltas(leaf).map(toDelta)
+    deltas = findDeltas(leaf).map(toDelta)
+  }
+
+  return this.buildFullFromDeltas(user, deltas)
+}
+
+DeltaCache.prototype.buildFullFromDeltas = function (user, deltas) {
+  var signalk = new FullSignalK(
+    this.app.selfId,
+    this.app.selfType,
+    JSON.parse(JSON.stringify(this.defaults))
+  )
+
+  if (deltas && deltas.length) {
     const secFilter = this.app.securityStrategy.shouldFilterDeltas()
       ? delta => this.app.securityStrategy.filterReadDelta(user, delta)
       : delta => true
-    deltas.filter(secFilter).forEach(signalk.addDelta.bind(signalk))
+    const addDelta = signalk.addDelta.bind(signalk)
+    deltas.filter(secFilter).forEach(addDelta)
   }
 
   return signalk.retrieve()

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,6 +127,14 @@ function Server(opts) {
     return providerStatus
   }
 
+  app.registerHistoryProvider = provider => {
+    app.historyProvider = provider
+  }
+
+  app.unregisterHistoryProvider = provider => {
+    delete app.historyProvider
+  }
+
   app.handleMessage = function(providerId, data) {
     if (data && data.updates) {
       incDeltaStatistics(app, providerId)

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -261,6 +261,7 @@ module.exports = function (app) {
       plugin = require(path.join(location, packageName))(appCopy)
     } catch (e) {
       console.error(`${packageName} failed to start: ${e.message}`)
+      console.error(e)
       app.setProviderError(packageName, `Failed to start: ${e.message}`)
       return
     }
@@ -290,6 +291,13 @@ module.exports = function (app) {
       onStopHandlers[plugin.id].push(
         app.registerActionHandler(context, path, plugin.id, callback)
       )
+    }
+
+    appCopy.registerHistoryProvider = provider => {
+      app.registerHistoryProvider(provider)
+      onStopHandlers[plugin.id].push(() => {
+        app.unregisterHistoryProvider(provider)
+      })
     }
 
     const options = getPluginOptions(plugin.id)

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -93,15 +93,26 @@ module.exports = function (app) {
           return res.json(last)
         }
 
-        if (req.query.time && app.historyProvider) {
-          app.historyProvider.getHistory(
-            new Date(req.query.time),
-            path,
-            deltas => {
-              var last = app.deltaCache.buildFullFromDeltas(req.skUser, deltas)
-              sendResult(last, path)
-            }
-          )
+        if (req.query.time) {
+          if (!app.historyProvider) {
+            res.status(404).send('No history provider')
+          } else {
+            app.historyProvider.getHistory(
+              new Date(req.query.time),
+              path,
+              deltas => {
+                if (deltas.length === 0) {
+                  res.status(404).send('No data found for the given time')
+                  return
+                }
+                var last = app.deltaCache.buildFullFromDeltas(
+                  req.skUser,
+                  deltas
+                )
+                sendResult(last, path)
+              }
+            )
+          }
         } else {
           var last = app.deltaCache.buildFull(req.skUser, path)
           sendResult(last, path)

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -73,25 +73,39 @@ module.exports = function (app) {
           }
         }
 
-        var last = app.deltaCache.buildFull(req.skUser, path)
+        function sendResult (last, path) {
+          if (last) {
+            for (var i in path) {
+              var p = path[i]
 
-        if (last) {
-          for (var i in path) {
-            var p = path[i]
-
-            if (typeof last[p] !== 'undefined') {
-              last = last[p]
-            } else {
-              next()
-              return
+              if (typeof last[p] !== 'undefined') {
+                last = last[p]
+              } else {
+                next()
+                return
+              }
             }
+          } else {
+            next()
+            return
           }
-        } else {
-          next()
-          return
+
+          return res.json(last)
         }
 
-        return res.json(last)
+        if (req.query.time && app.historyProvider) {
+          app.historyProvider.getHistory(
+            new Date(req.query.time),
+            path,
+            deltas => {
+              var last = app.deltaCache.buildFullFromDeltas(req.skUser, deltas)
+              sendResult(last, path)
+            }
+          )
+        } else {
+          var last = app.deltaCache.buildFull(req.skUser, path)
+          sendResult(last, path)
+        }
       })
 
       app.get(pathPrefix, function (req, res) {

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -177,24 +177,31 @@ module.exports = function (app) {
             }
           })
         }
+
         if (msg.subscribe) {
-          app.subscriptionmanager.subscribe(
-            msg,
-            unsubscribes,
-            spark.write.bind(this),
-            app.securityStrategy.shouldFilterDeltas()
-              ? msg => {
-                var filtered = app.securityStrategy.filterReadDelta(
-                  spark.request,
-                  msg
-                )
-                if (filtered) {
-                  spark.write(filtered)
+          if (spark.query.startTime) {
+            if (app.historyProvider) {
+              app.historyProvider.addSubscription(spark, msg)
+            }
+          } else {
+            app.subscriptionmanager.subscribe(
+              msg,
+              unsubscribes,
+              spark.write.bind(this),
+              app.securityStrategy.shouldFilterDeltas()
+                ? msg => {
+                  var filtered = app.securityStrategy.filterReadDelta(
+                    spark.request,
+                    msg
+                  )
+                  if (filtered) {
+                    spark.write(filtered)
+                  }
                 }
-              }
-              : spark.write.bind(this),
-            spark.request.skUser
-          )
+                : spark.write.bind(this),
+              spark.request.skUser
+            )
+          }
         }
         if (
           msg.unsubscribe &&
@@ -237,13 +244,8 @@ module.exports = function (app) {
       }
 
       onChange = wrapWithverifyWS(onChange)
-      app.signalk.on('delta', onChange)
-      spark.onDisconnects = [
-        () => {
-          app.signalk.removeListener('delta', onChange)
-        }
-      ]
 
+      spark.onDisconnects = []
       spark.onDisconnect = function () {
         spark.onDisconnects.forEach(f => f())
       }
@@ -256,38 +258,56 @@ module.exports = function (app) {
         roles: ['master', 'main']
       })
 
-      if (!spark.query.subscribe || spark.query.subscribe === 'self') {
-        app.deltaCache
-          .getCachedDeltas(
-            spark.request.skUser,
-            delta => delta.context === app.selfContext
-          )
-          .forEach(delta => spark.write(delta))
-      } else if (spark.query.subscribe === 'all') {
-        app.deltaCache
-          .getCachedDeltas(spark.request.skUser, delta => true)
-          .forEach(delta => spark.write(delta))
-      }
+      if (spark.query.startTime) {
+        if (_.isUndefined(app.historyProvider)) {
+          return // FIXME??
+        }
+        app.historyProvider.streamHistory(spark, spark.query, onChange)
+        spark.onDisconnects = [
+          () => {
+            app.historyProvider.stopStreaming(spark)
+          }
+        ]
+      } else {
+        app.signalk.on('delta', onChange)
+        spark.onDisconnects = [
+          () => {
+            app.signalk.removeListener('delta', onChange)
+          }
+        ]
 
-      if (spark.query.serverevents && spark.query.serverevents === 'all') {
-        const onServerEvent = wrapWithverifyWS(serverEvent => {
-          spark.write(serverEvent)
-        })
-        app.on('serverevent', onServerEvent)
-        spark.onDisconnects.push(() => {
-          app.removeListener('serverevent', onServerEvent)
-        })
-        Object.keys(app.lastServerEvents).forEach(propName => {
-          spark.write(app.lastServerEvents[propName])
-        })
-        if (app.securityStrategy.canAuthorizeWS()) {
-          spark.write({
-            type: 'RECEIVE_LOGIN_STATUS',
-            data: app.securityStrategy.getLoginStatus(spark.request)
+        if (!spark.query.subscribe || spark.query.subscribe === 'self') {
+          app.deltaCache
+            .getCachedDeltas(
+              spark.request.skUser,
+              delta => delta.context === app.selfContext
+            )
+            .forEach(delta => spark.write(delta))
+        } else if (spark.query.subscribe === 'all') {
+          app.deltaCache
+            .getCachedDeltas(spark.request.skUser, delta => true)
+            .forEach(delta => spark.write(delta))
+        }
+
+        if (spark.query.serverevents && spark.query.serverevents === 'all') {
+          const onServerEvent = wrapWithverifyWS(serverEvent => {
+            spark.write(serverEvent)
           })
+          app.on('serverevent', onServerEvent)
+          spark.onDisconnects.push(() => {
+            app.removeListener('serverevent', onServerEvent)
+          })
+          Object.keys(app.lastServerEvents).forEach(propName => {
+            spark.write(app.lastServerEvents[propName])
+          })
+          if (app.securityStrategy.canAuthorizeWS()) {
+            spark.write({
+              type: 'RECEIVE_LOGIN_STATUS',
+              data: app.securityStrategy.getLoginStatus(spark.request)
+            })
+          }
         }
       }
-
       function wrapWithverifyWS (theFunction) {
         if (!app.securityStrategy.canAuthorizeWS()) {
           return theFunction

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -179,9 +179,22 @@ module.exports = function (app) {
         }
 
         if (msg.subscribe) {
-          if (spark.query.startTime) {
+          if (msg.startTime) {
             if (app.historyProvider) {
-              app.historyProvider.addSubscription(spark, msg)
+              if (app.historyProvider.addSubscription) {
+                app.historyProvider.addSubscription(spark, {
+                  startTime: msg.startTime,
+                  playbackRate: msg.playbackRate
+                })
+              } else {
+                spark.end(
+                  'History provider does not support adding subscriptions'
+                )
+                return
+              }
+            } else {
+              spark.end('No history provider')
+              return
             }
           } else {
             app.subscriptionmanager.subscribe(

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -268,12 +268,12 @@ module.exports = function (app) {
         }
         app.historyProvider.hasAnyData(options, hasResults => {
           if (hasResults) {
-            app.historyProvider.streamHistory(spark, options, onChange)
-            spark.onDisconnects = [
-              () => {
-                app.historyProvider.stopStreaming(spark)
-              }
-            ]
+            const onDisconnect = app.historyProvider.streamHistory(
+              spark,
+              options,
+              onChange
+            )
+            spark.onDisconnects = [onDisconnect]
             spark.isHistory = true
           } else {
             spark.end('No data found')

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -263,12 +263,23 @@ module.exports = function (app) {
           spark.end('No history provider')
           return
         }
-        app.historyProvider.streamHistory(spark, spark.query, onChange)
-        spark.onDisconnects = [
-          () => {
-            app.historyProvider.stopStreaming(spark)
+        let options = {
+          startTime: new Date(spark.query.startTime),
+          playbackRate: spark.query.playbackRate,
+          subscribe: spark.query.subscribe
+        }
+        app.historyProvider.hasAnyData(options, hasResults => {
+          if (hasResults) {
+            app.historyProvider.streamHistory(spark, options, onChange)
+            spark.onDisconnects = [
+              () => {
+                app.historyProvider.stopStreaming(spark)
+              }
+            ]
+          } else {
+            spark.end('No data found')
           }
-        ]
+        })
       } else {
         app.signalk.on('delta', onChange)
         spark.onDisconnects = [

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -179,42 +179,27 @@ module.exports = function (app) {
         }
 
         if (msg.subscribe) {
-          if (msg.startTime) {
-            if (app.historyProvider) {
-              if (app.historyProvider.addSubscription) {
-                app.historyProvider.addSubscription(spark, {
-                  startTime: msg.startTime,
-                  playbackRate: msg.playbackRate
-                })
-              } else {
-                spark.end(
-                  'History provider does not support adding subscriptions'
-                )
-                return
-              }
-            } else {
-              spark.end('No history provider')
-              return
-            }
-          } else {
-            app.subscriptionmanager.subscribe(
-              msg,
-              unsubscribes,
-              spark.write.bind(this),
-              app.securityStrategy.shouldFilterDeltas()
-                ? msg => {
-                  var filtered = app.securityStrategy.filterReadDelta(
-                    spark.request,
-                    msg
-                  )
-                  if (filtered) {
-                    spark.write(filtered)
-                  }
-                }
-                : spark.write.bind(this),
-              spark.request.skUser
-            )
+          if (spark.isHistory) {
+            spark.end('Subscribe messages not supported with history playback')
+            return
           }
+          app.subscriptionmanager.subscribe(
+            msg,
+            unsubscribes,
+            spark.write.bind(this),
+            app.securityStrategy.shouldFilterDeltas()
+              ? msg => {
+                var filtered = app.securityStrategy.filterReadDelta(
+                  spark.request,
+                  msg
+                )
+                if (filtered) {
+                  spark.write(filtered)
+                }
+              }
+              : spark.write.bind(this),
+            spark.request.skUser
+          )
         }
         if (
           msg.unsubscribe &&
@@ -289,6 +274,7 @@ module.exports = function (app) {
                 app.historyProvider.stopStreaming(spark)
               }
             ]
+            spark.isHistory = true
           } else {
             spark.end('No data found')
           }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -276,6 +276,7 @@ module.exports = function (app) {
           }
         ]
 
+        const boundWrite = spark.write.bind(spark)
         if (!spark.query.subscribe || spark.query.subscribe === 'self') {
           app.deltaCache
             .getCachedDeltas(
@@ -286,13 +287,11 @@ module.exports = function (app) {
         } else if (spark.query.subscribe === 'all') {
           app.deltaCache
             .getCachedDeltas(spark.request.skUser, delta => true)
-            .forEach(delta => spark.write(delta))
+            .forEach(boundWrite)
         }
 
         if (spark.query.serverevents && spark.query.serverevents === 'all') {
-          const onServerEvent = wrapWithverifyWS(serverEvent => {
-            spark.write(serverEvent)
-          })
+          const onServerEvent = wrapWithverifyWS(boundWrite)
           app.on('serverevent', onServerEvent)
           spark.onDisconnects.push(() => {
             app.removeListener('serverevent', onServerEvent)

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -260,7 +260,8 @@ module.exports = function (app) {
 
       if (spark.query.startTime) {
         if (_.isUndefined(app.historyProvider)) {
-          return // FIXME??
+          spark.end('No history provider')
+          return
         }
         app.historyProvider.streamHistory(spark, spark.query, onChange)
         spark.onDisconnects = [

--- a/test/history.js
+++ b/test/history.js
@@ -32,7 +32,6 @@ let dummyHistoryProvider = app => {
       }, 100)
     },
     stopStreaming: cookie => {},
-    addSubscription: (cookie, msg) => {},
     getHistory: (date, path, cb) => {
       testDelta.context = `vessels.${app.selfId}`
       cb([testDelta])
@@ -79,6 +78,9 @@ describe('History', _ => {
     msg.should.not.equal('timeout')
     let delta = JSON.parse(msg)
     delta.updates[0].values[0].path.should.equal('performance.velocityMadeGood')
+
+    msg = await wsPromiser.nextMsg()
+    msg.should.equal('timeout')
   })
 
   it('REST time request works', async function () {

--- a/test/history.js
+++ b/test/history.js
@@ -7,7 +7,8 @@ const Server = require('../lib')
 const fetch = require('node-fetch')
 const { WsPromiser } = require('./servertestutilities')
 
-let testDelta = {
+const testDeltaDate = new Date('2018-08-09T14:07:29.695Z')
+const testDelta = {
   updates: [
     {
       timestamp: '2018-08-09T14:07:29.695Z',
@@ -30,14 +31,18 @@ let dummyHistoryProvider = app => {
         testDelta.context = `vessels.${app.selfId}`
         onDelta(testDelta)
       }, 100)
+      return () => {}
     },
-    stopStreaming: cookie => {},
     getHistory: (date, path, cb) => {
       testDelta.context = `vessels.${app.selfId}`
-      cb([testDelta])
+      if (date.getTime() == testDeltaDate.getTime()) {
+        cb([testDelta])
+      } else {
+        cb([])
+      }
     },
     hasAnyData: (options, cb) => {
-      cb(true)
+      cb(options.startTime.getTime() == testDeltaDate.getTime())
     }
   }
 }
@@ -68,7 +73,7 @@ describe('History', _ => {
 
   it('startTime subscription works', async function () {
     var wsPromiser = new WsPromiser(
-      `ws://0.0.0.0:${port}/signalk/v1/stream?subscribe=self&startTime=2018-08-23T12:39:48Z`
+      `ws://0.0.0.0:${port}/signalk/v1/stream?subscribe=self&startTime=2018-08-09T14:07:29.695Z`
     )
     var msg = await wsPromiser.nextMsg()
     msg.should.not.equal('timeout')
@@ -85,10 +90,17 @@ describe('History', _ => {
 
   it('REST time request works', async function () {
     var result = await fetch(
-      `${url}/signalk/v1/api/vessels/self?time=2018-08-23T12:39:48Z`
+      `${url}/signalk/v1/api/vessels/self?time=2018-08-09T14:07:29.695Z`
     )
     result.status.should.equal(200)
     var json = await result.json()
     json.should.have.nested.property('performance.velocityMadeGood')
+  })
+
+  it('REST time request with no data  works', async function () {
+    var result = await fetch(
+      `${url}/signalk/v1/api/vessels/self?time=2018-08-09T14:07:29.694Z`
+    )
+    result.status.should.equal(404)
   })
 })

--- a/test/history.js
+++ b/test/history.js
@@ -1,0 +1,123 @@
+const chai = require('chai')
+chai.Should()
+chai.use(require('chai-things'))
+const _ = require('lodash')
+const freeport = require('freeport-promise')
+const WebSocket = require('ws')
+const Server = require('../lib')
+const fetch = require('node-fetch')
+
+let testDelta = {
+  updates: [
+    {
+      timestamp: '2018-08-09T14:07:29.695Z',
+      values: [
+        { path: 'performance.velocityMadeGood', value: 0.16641505293384623 },
+        {
+          path: 'performance.beatAngleVelocityMadeGood',
+          value: 0.16641505293384623
+        }
+      ],
+      $source: 'test-source'
+    }
+  ]
+}
+
+let dummyHistoryProvider = app => {
+  return {
+    streamHistory: (cookie, query, onDelta) => {
+      setTimeout(() => {
+        testDelta.context = `vessels.${app.selfId}`
+        onDelta(testDelta)
+      }, 100)
+    },
+    stopStreaming: cookie => {},
+    addSubscription: (cookie, msg) => {},
+    getHistory: (date, path, cb) => {
+      testDelta.context = `vessels.${app.selfId}`
+      cb([testDelta])
+    }
+  }
+}
+
+describe('History', _ => {
+  var server, url, port
+
+  before(async function () {
+    port = await freeport()
+    url = `http://0.0.0.0:${port}`
+    const serverApp = new Server({
+      config: {
+        settings: {
+          port,
+          interfaces: {
+            plugins: false
+          }
+        }
+      }
+    })
+    server = await serverApp.start()
+    server.app.registerHistoryProvider(dummyHistoryProvider(server.app))
+  })
+
+  after(async function () {
+    await server.stop()
+  })
+
+  it('startTime subscription works', async function () {
+    var wsPromiser = new WsPromiser(
+      `ws://0.0.0.0:${port}/signalk/v1/stream?subscribe=self&startTime=2018-08-23T12:39:48Z`
+    )
+    var msg = await wsPromiser.nextMsg()
+    msg.should.not.equal('timeout')
+    JSON.parse(msg)
+
+    msg = await wsPromiser.nextMsg()
+    msg.should.not.equal('timeout')
+    let delta = JSON.parse(msg)
+    delta.updates[0].values[0].path.should.equal('performance.velocityMadeGood')
+  })
+
+  it('REST time request works', async function () {
+    var result = await fetch(
+      `${url}/signalk/v1/api/vessels/self?time=2018-08-23T12:39:48Z`
+    )
+    result.status.should.equal(200)
+    var json = await result.json()
+    json.should.have.nested.property('performance.velocityMadeGood')
+  })
+})
+
+// Connects to the url via ws
+// and provides Promises that are either resolved within
+// timeout period as the next message from the ws or
+// the string "timeout" in case timeout fires
+function WsPromiser (url) {
+  this.ws = new WebSocket(url)
+  this.ws.on('message', this.onMessage.bind(this))
+  this.callees = []
+}
+
+WsPromiser.prototype.nextMsg = function () {
+  const callees = this.callees
+  return new Promise((resolve, reject) => {
+    callees.push(resolve)
+    setTimeout(_ => {
+      resolve('timeout')
+    }, 250)
+  })
+}
+
+WsPromiser.prototype.onMessage = function (message) {
+  const theCallees = this.callees
+  this.callees = []
+  theCallees.forEach(callee => callee(message))
+}
+
+WsPromiser.prototype.send = function (message) {
+  const that = this
+  return new Promise((resolve, reject) => {
+    that.ws.send(JSON.stringify(message))
+    setTimeout(() => resolve('wait over'), 100)
+  })
+}

--- a/test/security.js
+++ b/test/security.js
@@ -8,6 +8,7 @@ const http = require('http')
 const promisify = require('util').promisify
 const WebSocket = require('ws')
 const _ = require('lodash')
+const { WsPromiser } = require('./servertestutilities')
 
 const limitedSteeringDelta = {
   updates: [
@@ -249,37 +250,3 @@ describe('Security', () => {
     result.status.should.equal(401)
   })
 })
-
-// Connects to the url via ws
-// and provides Promises that are either resolved within
-// timeout period as the next message from the ws or
-// the string "timeout" in case timeout fires
-function WsPromiser (url) {
-  this.ws = new WebSocket(url)
-  this.ws.on('message', this.onMessage.bind(this))
-  this.callees = []
-}
-
-WsPromiser.prototype.nextMsg = function () {
-  const callees = this.callees
-  return new Promise((resolve, reject) => {
-    callees.push(resolve)
-    setTimeout(_ => {
-      resolve('timeout')
-    }, 250)
-  })
-}
-
-WsPromiser.prototype.onMessage = function (message) {
-  const theCallees = this.callees
-  this.callees = []
-  theCallees.forEach(callee => callee(message))
-}
-
-WsPromiser.prototype.send = function (message) {
-  const that = this
-  return new Promise((resolve, reject) => {
-    that.ws.send(JSON.stringify(message))
-    setTimeout(() => resolve('wait over'), 100)
-  })
-}

--- a/test/servertestutilities.js
+++ b/test/servertestutilities.js
@@ -1,4 +1,41 @@
+const WebSocket = require('ws')
+
+// Connects to the url via ws
+// and provides Promises that are either resolved within
+// timeout period as the next message from the ws or
+// the string "timeout" in case timeout fires
+function WsPromiser (url) {
+  this.ws = new WebSocket(url)
+  this.ws.on('message', this.onMessage.bind(this))
+  this.callees = []
+}
+
+WsPromiser.prototype.nextMsg = function () {
+  const callees = this.callees
+  return new Promise((resolve, reject) => {
+    callees.push(resolve)
+    setTimeout(_ => {
+      resolve('timeout')
+    }, 250)
+  })
+}
+
+WsPromiser.prototype.onMessage = function (message) {
+  const theCallees = this.callees
+  this.callees = []
+  theCallees.forEach(callee => callee(message))
+}
+
+WsPromiser.prototype.send = function (message) {
+  const that = this
+  return new Promise((resolve, reject) => {
+    that.ws.send(JSON.stringify(message))
+    setTimeout(() => resolve('wait over'), 100)
+  })
+}
+
 module.exports = {
+  WsPromiser: WsPromiser,
   startServerP: function startServerP (port) {
     const Server = require('../lib')
     const server = new Server({

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -3,7 +3,7 @@ const assert = require('assert')
 const freeport = require('freeport-promise')
 const WebSocket = require('ws')
 const rp = require('request-promise')
-const startServerP = require('./servertestutilities').startServerP
+const { startServerP, WsPromiser } = require('./servertestutilities')
 
 function getDelta (overwrite) {
   const delta = {
@@ -482,37 +482,3 @@ describe('Subscriptions', _ => {
       })
   })
 })
-
-// Connects to the url via ws
-// and provides Promises that are either resolved within
-// timeout period as the next message from the ws or
-// the string "timeout" in case timeout fires
-function WsPromiser (url) {
-  this.ws = new WebSocket(url)
-  this.ws.on('message', this.onMessage.bind(this))
-  this.callees = []
-}
-
-WsPromiser.prototype.nextMsg = function () {
-  const callees = this.callees
-  return new Promise((resolve, reject) => {
-    callees.push(resolve)
-    setTimeout(_ => {
-      resolve('timeout')
-    }, 250)
-  })
-}
-
-WsPromiser.prototype.onMessage = function (message) {
-  const theCallees = this.callees
-  this.callees = []
-  theCallees.forEach(callee => callee(message))
-}
-
-WsPromiser.prototype.send = function (message) {
-  const that = this
-  return new Promise((resolve, reject) => {
-    that.ws.send(JSON.stringify(message))
-    setTimeout(() => resolve('wait over'), 100)
-  })
-}


### PR DESCRIPTION
This adds new parameters to the ws subscribe request **startTime** and **playbackRate**. This will start the stream at the given startTime and play it back at the given rate (2 for example)

`wss://localhost:3443/signalk/v1/stream?subscribe=self&startTime=2018-08-24T15:19:09Z&playbackRate=5`

Also adds a time parameter to REST requests. This will return the vessel state at the given time.

https://localhost:3443/signalk/v1/api/vessels/self?time=2018-08-24T15:19:09Z

