### PR TITLE
[WIP] feature: make the server keep a list of N2K PGNs that are transmitted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -136,6 +136,23 @@ function Server(opts) {
     delete app.historyProvider
   }
 
+  app.transmitPGNs = {}
+  app.registerToTransmitPGNs = (id, pgns) => {
+    app.transmitPGNs[id] = pgns
+    debug('%s registered as transmitting pgns: %j', id, pgns)
+  }
+
+  app.unregisterToTransmitPGNs = id => {
+    delete app.transmitPGNs[id]
+  }
+
+  app.getTransmitPGNs = () => {
+    return _.values(app.transmitPGNs).reduce((acc, pgns) => {
+      acc.push(...pgns)
+      return acc
+    }, [])
+  }
+
   app.handleMessage = function(providerId, data) {
     if (data && data.updates) {
       incDeltaStatistics(app, providerId)

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -300,6 +300,13 @@ module.exports = function (app) {
       })
     }
 
+    appCopy.registerToTransmitPGNs = (id, pgns) => {
+      app.registerToTransmitPGNs(id, pgns)
+      onStopHandlers[plugin.id].push(() => {
+        app.unregisterToTransmitPGNs(id)
+      })
+    }
+
     const options = getPluginOptions(plugin.id)
     const restart = newConfiguration => {
       const pluginOptions = getPluginOptions(plugin.id)


### PR DESCRIPTION

In canboatjs I currently hard code the list of PGNs that signalk-to-nmea2000 sends out. 

This allows that list to be dynamic and allows other plugins to also get in the list.