### PR TITLE
chore: update to latest version of nmea0183-signalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@signalk/instrumentpanel": "^0.3.0",
     "@signalk/maptracker": "^1.0.0",
     "@signalk/n2k-signalk": "^1.2.1",
-    "@signalk/nmea0183-signalk": "^2.2.0",
+    "@signalk/nmea0183-signalk": "^3.0.0",
     "@signalk/playground": "^1.0.0",
     "@signalk/plugin-config": "^1.0.0",
     "@signalk/sailgauge": "^1.1.0",


### PR DESCRIPTION
This PR updates `signalk-server` to work with the new API of `nmea0183-signalk` introduced in https://github.com/SignalK/signalk-parser-nmea0183/pull/130

Testing I have done:
 - Start `bin/nmea-from-file` and verify that data is still flowing
 - Add a manual TCP NMEA provider
   - Verified that data is received and parsed
   - Verified that a logfile is generated when `logging: true` and that it contains NMEA data

This probably deserves more testing. Suggestions welcomed!


> **Note:**
>  this PR is marked WIP because we still need to release a new version of nmea0183-signalk and update `package.json` to point to it.
