### PR TITLE
feature: 0183 TCP server duplex, sentenceEvent

### DIFF
--- a/lib/interfaces/nmea-tcp.js
+++ b/lib/interfaces/nmea-tcp.js
@@ -33,6 +33,9 @@ module.exports = function (app) {
       socket.name = socket.remoteAddress + ':' + socket.remotePort
       debug('Connected:' + socket.id + ' ' + socket.name)
       openSockets[socket.id] = socket
+      socket.on('data', data => {
+        app.emit('tcpserver0183data', data)
+      })
       socket.on('end', function () {
         // client disconnects
         debug('Ended:' + socket.id + ' ' + socket.name)

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -149,9 +149,11 @@ class LoggingInput extends Component {
 }
 
 class ValidateChecksumInput extends Component {
-  constructor(props) {
+  constructor (props) {
     super(props)
-    this.props.value.validateChecksum = typeof this.props.value.validateChecksum === 'undefined' || this.props.value.validateChecksum
+    this.props.value.validateChecksum =
+      typeof this.props.value.validateChecksum === 'undefined' ||
+      this.props.value.validateChecksum
   }
   render () {
     return (
@@ -177,6 +179,20 @@ class ValidateChecksumInput extends Component {
   }
 }
 
+class SentenceEventInput extends Component {
+  render () {
+    return (
+      <TextInput
+        title='sentenceEvent'
+        name='options.sentenceEvent'
+        helpText='Example: nmea1data'
+        value={this.props.value.sentenceEvent}
+        onChange={this.props.onChange}
+      />
+    )
+  }
+}
+
 class DataTypeInput extends Component {
   render () {
     return (
@@ -192,7 +208,7 @@ class DataTypeInput extends Component {
             onChange={event => this.props.onChange(event)}
           >
             <option value='SignalK'>Signal K</option>
-        <option value='NMEA2000'>NMEA 2000 (canboat)</option>
+            <option value='NMEA2000'>NMEA 2000 (canboat)</option>
             <option value='NMEA2000JS'>NMEA 2000 (canboatjs)</option>
             <option value='NMEA0183'>NMEA 0183</option>
             {this.props.value.type === 'FileStream' && (
@@ -247,6 +263,37 @@ class HostInput extends Component {
   }
 }
 
+class Suppress0183Checkbox extends Component {
+  constructor (props) {
+    super(props)
+    this.props.value.suppress0183event =
+      typeof this.props.value.suppress0183event === 'undefined' ||
+      this.props.value.suppress0183event
+  }
+  render () {
+    return (
+      <FormGroup row>
+        <Col xs='3' md='2'>
+          <Label>Suppress nmea0183 event</Label>
+        </Col>
+        <Col xs='2' md='3'>
+          <Label className='switch switch-text switch-primary'>
+            <Input
+              type='checkbox'
+              name='options.suppress0183event'
+              className='switch-input'
+              onChange={event => this.props.onChange(event)}
+              checked={this.props.value.suppress0183event}
+            />
+            <span className='switch-label' data-on='Yes' data-off='No' />
+            <span className='switch-handle' />
+          </Label>
+        </Col>
+      </FormGroup>
+    )
+  }
+}
+
 const NMEA2000 = props => {
   return (
     <div>
@@ -269,10 +316,12 @@ const NMEA2000 = props => {
           </Input>
         </Col>
       </FormGroup>
-      {(props.value.options.type === 'ngt-1' || props.value.options.type === 'ngt-1-canboatjs')  && (
+      {(props.value.options.type === 'ngt-1' ||
+        props.value.options.type === 'ngt-1-canboatjs') && (
         <DeviceInput value={props.value.options} onChange={props.onChange} />
       )}
-      {(props.value.options.type === 'canbus' || props.value.options.type === 'canbus-canboatjs') && (
+      {(props.value.options.type === 'canbus' ||
+        props.value.options.type === 'canbus-canboatjs') && (
         <TextInput
           title='Interface'
           name='options.interface'
@@ -301,10 +350,17 @@ const NMEA0183 = props => {
           >
             <option>Select a source</option>
             <option value='serial'>Serial</option>
-            <option value='tcp'>TCP</option>
+            <option value='tcp'>TCP Client</option>
+            <option value='tcpserver'>TCP Server</option>
             <option value='udp'>UDP</option>
           </Input>
         </Col>
+        {props.value.options.type === 'tcpserver' && (
+          <Col xs='12' md='6'>
+            Make this server's NMEA 10110 server bidirectional so that input
+            from clients is converted to Signal K.
+          </Col>
+        )}
       </FormGroup>
       {props.value.options.type === 'serial' && (
         <div>
@@ -321,9 +377,21 @@ const NMEA0183 = props => {
           <PortInput value={props.value.options} onChange={props.onChange} />
         </div>
       )}
+      {props.value.options.type === 'tcpserver' && (
+        <div>
+          <Suppress0183Checkbox
+            value={props.value.options}
+            onChange={props.onChange}
+          />
+        </div>
+      )}
       {props.value.options.type === 'udp' && (
         <PortInput value={props.value.options} onChange={props.onChange} />
       )}
+      <SentenceEventInput
+        value={props.value.options}
+        onChange={props.onChange}
+      />
       <ValidateChecksumInput
         value={props.value.options}
         onChange={props.onChange}
@@ -357,41 +425,41 @@ const SignalK = props => {
       {(props.value.options.type === 'ws' ||
         props.value.options.type === 'wss' ||
         props.value.options.type === 'tcp') && (
-          <div>
-            {(props.value.options.type === 'ws' ||
+        <div>
+          {(props.value.options.type === 'ws' ||
             props.value.options.type === 'wss') && (
-                <FormGroup row>
-                  <Col xs='0' md='2'>
-                    <Label />
-                  </Col>
-                  <Col xs='12' md='3'>
-                    <div className='checkbox'>
-                      <Label check htmlFor='enabled'>
-                        <Input
-                          type='checkbox'
-                          name='options.useDiscovery'
-                          onChange={props.onChange}
-                          checked={props.value.options.useDiscovery}
-                        />Use Discovery
-                      </Label>
-                    </div>
-                  </Col>
-                </FormGroup>
-              )}
-            {!props.value.options.useDiscovery && (
-              <div>
-                <HostInput
-                  value={props.value.options}
-                  onChange={props.onChange}
-                />
-                <PortInput
-                  value={props.value.options}
-                  onChange={props.onChange}
-                />
-              </div>
-            )}
-          </div>
-        )}
+            <FormGroup row>
+              <Col xs='0' md='2'>
+                <Label />
+              </Col>
+              <Col xs='12' md='3'>
+                <div className='checkbox'>
+                  <Label check htmlFor='enabled'>
+                    <Input
+                      type='checkbox'
+                      name='options.useDiscovery'
+                      onChange={props.onChange}
+                      checked={props.value.options.useDiscovery}
+                    />Use Discovery
+                  </Label>
+                </div>
+              </Col>
+            </FormGroup>
+          )}
+          {!props.value.options.useDiscovery && (
+            <div>
+              <HostInput
+                value={props.value.options}
+                onChange={props.onChange}
+              />
+              <PortInput
+                value={props.value.options}
+                onChange={props.onChange}
+              />
+            </div>
+          )}
+        </div>
+      )}
       {props.value.options.type === 'udp' && (
         <PortInput value={props.value.options} onChange={props.onChange} />
       )}

--- a/providers/nmea0183-signalk.js
+++ b/providers/nmea0183-signalk.js
@@ -44,7 +44,8 @@ function nmea0183ToSignalK (options) {
   this.sentenceEventEmitter = options.app.signalk
 
   // Prepare a list of events to send for each sentence received
-  this.sentenceEvents = ['nmea0183']
+  this.sentenceEvents = options.suppress0183event ? [] : ['nmea0183']
+
   if (options.sentenceEvent) {
     if (Array.isArray(options.sentenceEvent)) {
       this.sentenceEvents = this.sentenceEvents.concat(options.sentenceEvent)

--- a/providers/simple.js
+++ b/providers/simple.js
@@ -12,6 +12,7 @@ const Liner = require('./liner')
 const execute = require('./execute')
 const Udp = require('./udp')
 const Tcp = require('./tcp')
+const TcpServer = require('./tcpserver')
 const FileStream = require('./filestream')
 const Throttle = require('./throttle')
 const TimestampThrottle = require('./timestamp-throttle')
@@ -177,6 +178,8 @@ function nmea2000input (subOptions, logging) {
 function nmea0183input (subOptions) {
   if (subOptions.type == 'tcp') {
     return [new Tcp(subOptions), new Liner(subOptions)]
+  } else if (subOptions.type === 'tcpserver') {
+    return [new TcpServer(subOptions), new Liner(subOptions)]
   } else if (subOptions.type === 'udp') {
     return [new Udp(subOptions)]
   } else if (subOptions.type === 'serial') {

--- a/providers/tcpserver.js
+++ b/providers/tcpserver.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Teppo Kurki <teppo.kurki@iki.fi>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ The server is the tcp nmea0183 interface, this provider just
+ shovels data from tcpserver0183data to the provider pipe.
+ */
+
+const Transform = require('stream').Transform
+
+function TcpServer (options) {
+  Transform.call(this)
+  this.options = options
+}
+
+require('util').inherits(TcpServer, Transform)
+
+TcpServer.prototype.pipe = function (pipeTo) {
+  this.options.app.on('tcpserver0183data', d => this.write(d))
+  Transform.prototype.pipe.call(this, pipeTo)
+}
+
+TcpServer.prototype._transform = function (data, encoding, callback) {
+  callback(null, data)
+}
+
+module.exports = TcpServer


### PR DESCRIPTION
This adds the ability to use the server's NMEA 0183
TCP server for bidirectional communications. The server listens
for 'nmea0183' events, so we will need to be able to
suppress echoing the incoming data back to the client.
Thus we need an option to suppress sending sentences
as 'nmea0183' events.

This also adds also the ability to specify one
sentenceEvent name for emitting sentences from the
0183 parser.