### PR TITLE
feature: getSelfStream/Bus per sourceId

### DIFF
--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -16,6 +16,7 @@
 
 var Bacon = require('baconjs')
 const _ = require('lodash')
+const isUndefined = _.isUndefined
 
 function StreamBundle (selfId) {
   this.selfContext = 'vessels.' + selfId
@@ -89,7 +90,13 @@ StreamBundle.prototype.push = function (path, pathValueWithSourceAndContext) {
   this.getBus(path).push(pathValueWithSourceAndContext)
   if (pathValueWithSourceAndContext.context === this.selfContext) {
     this.getSelfBus(path).push(pathValueWithSourceAndContext)
+    this.getSelfBus(path, pathValueWithSourceAndContext.$source).push(
+      pathValueWithSourceAndContext
+    )
     this.getSelfStream(path).push(pathValueWithSourceAndContext.value)
+    this.getSelfStream(path, pathValueWithSourceAndContext.$source).push(
+      pathValueWithSourceAndContext.value
+    )
   }
 }
 
@@ -102,18 +109,20 @@ StreamBundle.prototype.getBus = function (path) {
   return result
 }
 
-StreamBundle.prototype.getSelfStream = function (path) {
-  var result = this.streams[path]
+StreamBundle.prototype.getSelfStream = function (path, sourceId = undefined) {
+  const pathWithSourceId = getPathWithSourceId(path, sourceId)
+  let result = this.streams[pathWithSourceId]
   if (!result) {
-    result = this.streams[path] = new Bacon.Bus()
+    result = this.streams[pathWithSourceId] = new Bacon.Bus()
   }
   return result
 }
 
-StreamBundle.prototype.getSelfBus = function (path) {
-  var result = this.selfBuses[path]
+StreamBundle.prototype.getSelfBus = function (path, sourceId = undefined) {
+  const pathWithSourceId = getPathWithSourceId(path, sourceId)
+  let result = this.selfBuses[pathWithSourceId]
   if (!result) {
-    result = this.selfBuses[path] = new Bacon.Bus()
+    result = this.selfBuses[pathWithSourceId] = new Bacon.Bus()
   }
   return result
 }
@@ -140,5 +149,8 @@ function toDelta (normalizedDeltaData) {
     ]
   }
 }
+
+const getPathWithSourceId = (path, sourceId) =>
+  path + (isUndefined(sourceId) ? '' : `.${sourceId}`)
 
 module.exports = { StreamBundle, toDelta }

--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -50,7 +50,8 @@ StreamBundle.prototype.pushDelta = function (delta) {
                 context: delta.context,
                 source: update.source,
                 $source: update.$source,
-                timestamp: update.timestamp
+                timestamp: update.timestamp,
+                key: getPathWithSourceId(pathValue.path, update.$source)
               })
             })
           }, this)
@@ -89,12 +90,12 @@ StreamBundle.prototype.push = function (path, pathValueWithSourceAndContext) {
   }
   this.getBus(path).push(pathValueWithSourceAndContext)
   if (pathValueWithSourceAndContext.context === this.selfContext) {
-    this.getSelfBus(path).push(pathValueWithSourceAndContext)
-    this.getSelfBus(path, pathValueWithSourceAndContext.$source).push(
+    this.getSelfBusByKey(path).push(pathValueWithSourceAndContext)
+    this.getSelfBusByKey(pathValueWithSourceAndContext.key).push(
       pathValueWithSourceAndContext
     )
-    this.getSelfStream(path).push(pathValueWithSourceAndContext.value)
-    this.getSelfStream(path, pathValueWithSourceAndContext.$source).push(
+    this.getSelfStreamByKey(path).push(pathValueWithSourceAndContext.value)
+    this.getSelfStreamByKey(pathValueWithSourceAndContext.key).push(
       pathValueWithSourceAndContext.value
     )
   }
@@ -110,21 +111,25 @@ StreamBundle.prototype.getBus = function (path) {
 }
 
 StreamBundle.prototype.getSelfStream = function (path, sourceId = undefined) {
-  const pathWithSourceId = getPathWithSourceId(path, sourceId)
-  let result = this.streams[pathWithSourceId]
-  if (!result) {
-    result = this.streams[pathWithSourceId] = new Bacon.Bus()
-  }
-  return result
+  return getSelfStreamByKey(getPathWithSourceId(path, sourceId))
+}
+
+StreamBundle.prototype.getSelfStreamByKey = function (pathWithSourceId) {
+  return (
+    this.streams[pathWithSourceId] ||
+    (this.streams[pathWithSourceId] = new Bacon.Bus())
+  )
 }
 
 StreamBundle.prototype.getSelfBus = function (path, sourceId = undefined) {
-  const pathWithSourceId = getPathWithSourceId(path, sourceId)
-  let result = this.selfBuses[pathWithSourceId]
-  if (!result) {
-    result = this.selfBuses[pathWithSourceId] = new Bacon.Bus()
-  }
-  return result
+  return this.getSelfBusByKey(getPathWithSourceId(path, sourceId))
+}
+
+StreamBundle.prototype.getSelfBusByKey = function (pathWithSourceId) {
+  return (
+    this.selfBuses[pathWithSourceId] ||
+    (this.selfBuses[pathWithSourceId] = new Bacon.Bus())
+  )
 }
 
 StreamBundle.prototype.getAvailablePaths = function () {


### PR DESCRIPTION
Add the ability for plugins to get sourceId specific datastreams.
Current API allows only per path self streams.