### PR TITLE
fix: REST api to GET a value not working

### DIFF
--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -82,7 +82,7 @@ DeltaCache.prototype.buildFull = function (user, path) {
     this.cache,
     pathToProcessForFull(path),
     false,
-    false
+    true
   )
 
   let deltas


### PR DESCRIPTION
GET /signalk/v1/api/vessels/self/electrical/batteries/1/voltage

Works and has a value in it, but

/signalk/v1/api/vessels/self/electrical/batteries/1/voltage/value

returns a 404