### PR TITLE
feature: add script to report which serial devices the server is using

### DIFF
--- a/bin/signalk-list-devices
+++ b/bin/signalk-list-devices
@@ -21,13 +21,18 @@ const fs = require('fs')
 
 var args = minimist(process.argv.slice(2))
 
-var settingsPath = args.settings || args.s
+var settingsPath = args.settings || args.s 
+var format = args.format || args.f
 
 if ( !settingsPath ) {
   console.error(
-    'usage: list-devices -s /path/to/settings.json'
+    'usage: list-devices -s /path/to/settings.json -f [json|text]'
   )
   process.exit(1)
+}
+
+if ( !format ) {
+  format = 'json'
 }
 
 let settings = require(settingsPath)
@@ -36,7 +41,7 @@ let devices = []
 
 if ( settings.pipedProviders ) {
   settings.pipedProviders.forEach(provider => {
-    if ( provider.enabled && provider.pipeElements ) {
+    if ( !provider.enabled  && provider.pipeElements ) {
       provider.pipeElements.forEach(el => {
         if ( el.type === 'providers/simple' ) {
           if ( el.options && el.options.subOptions && el.options.subOptions.device  ) {
@@ -48,7 +53,14 @@ if ( settings.pipedProviders ) {
   })
 }
 
-console.log(JSON.stringify(devices))
+if ( format === 'json' ) {
+  console.log(JSON.stringify(devices))
+} else {
+  devices.forEach(d => {
+    process.stdout.write(d + ' ')
+  })
+  process.stdout.write('\n')
+}
 
             
 

--- a/bin/signalk-list-devices
+++ b/bin/signalk-list-devices
@@ -41,7 +41,7 @@ let devices = []
 
 if ( settings.pipedProviders ) {
   settings.pipedProviders.forEach(provider => {
-    if ( !provider.enabled  && provider.pipeElements ) {
+    if ( provider.enabled  && provider.pipeElements ) {
       provider.pipeElements.forEach(el => {
         if ( el.type === 'providers/simple' ) {
           if ( el.options && el.options.subOptions && el.options.subOptions.device  ) {

--- a/bin/signalk-list-devices
+++ b/bin/signalk-list-devices
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+/*
+ * Copyright 2018 Scott Bender <scott@scottbender.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+const minimist = require('minimist')
+const fs = require('fs')
+
+var args = minimist(process.argv.slice(2))
+
+var settingsPath = args.settings || args.s
+
+if ( !settingsPath ) {
+  console.error(
+    'usage: list-devices -s /path/to/settings.json'
+  )
+  process.exit(1)
+}
+
+let settings = require(settingsPath)
+
+let devices = []
+
+if ( settings.pipedProviders ) {
+  settings.pipedProviders.forEach(provider => {
+    if ( provider.enabled && provider.pipeElements ) {
+      provider.pipeElements.forEach(el => {
+        if ( el.type === 'providers/simple' ) {
+          if ( el.options && el.options.subOptions && el.options.subOptions.device  ) {
+            devices.push(el.options.subOptions.device)
+          }
+        }
+      })
+    }
+  })
+}
+
+console.log(JSON.stringify(devices))
+
+            
+


### PR DESCRIPTION
This is needed for the venus install, so that they can ignore devices that signalk is using