### PR TITLE
feature: start with invalid provider config

### DIFF
--- a/lib/pipedproviders.js
+++ b/lib/pipedproviders.js
@@ -64,8 +64,13 @@ module.exports = function (app) {
   function startProviders () {
     if (app.config.settings.pipedProviders) {
       piped = app.config.settings.pipedProviders.reduce((result, config) => {
-        if (typeof config.enabled === 'undefined' || config.enabled) {
-          result.push(createPipedProvider(config))
+        try {
+          if (typeof config.enabled === 'undefined' || config.enabled) {
+            result.push(createPipedProvider(config))
+          }
+        } catch (e) {
+          app.setProviderError(config.id, e.message)
+          console.error(e.message)
         }
         return result
       }, [])


### PR DESCRIPTION
We should start with invalid provider configuration so that
the user has access to the admin UI to fix the mistake. With 
this change the valid providers will start and log the invalid
one.