### PR TITLE
feature: start with tcp ports in use

### DIFF
--- a/lib/interfaces/nmea-tcp.js
+++ b/lib/interfaces/nmea-tcp.js
@@ -57,8 +57,13 @@ module.exports = function (app) {
     }
     app.signalk.on('nmea0183', send)
     app.on('nmea0183out', send)
+    server.on('listening', () =>
+      debug('NMEA0138 tcp server listening on ' + port)
+    )
+    server.on('error', e => {
+      console.error(`NMEA0138 tcp server error: ${e.message}`)
+    })
     server.listen(port)
-    debug('NMEA0138 tcp server listening on ' + port)
   }
 
   api.stop = function () {

--- a/lib/interfaces/tcp.js
+++ b/lib/interfaces/tcp.js
@@ -73,6 +73,14 @@ module.exports = function (app) {
         }
       })
     })
+
+    server.on('listening', () =>
+      debug('Signal K tcp server listening on ' + port)
+    )
+    server.on('error', e => {
+      console.error(`Signal K tcp server error: ${e.message}`)
+    })
+
     if (process.env.TCPSTREAMADDRESS) {
       debug('Binding to ' + process.env.TCPSTREAMADDRESS)
       server.listen(port, process.env.TCPSTREAMADDRESS)


### PR DESCRIPTION
People seem to be frequently starting the server manually
with the systemd managed one already started and the startup
fails with enigmatic EADDRINUSE 10110 stuff. This changes the
server so that it just logs error about the overlapping
NMEA0183 and Signal K server tcp ports and proceeds to
start the server.