### PR TITLE
feature: use list of available serial ports

### DIFF
--- a/lib/serverroutes.js
+++ b/lib/serverroutes.js
@@ -24,6 +24,7 @@ const { getHttpPort, getSslPort } = require('./ports')
 const express = require('express')
 const { getAISShipTypeName } = require('@signalk/signalk-schema')
 const { queryRequest } = require('./requestResponse')
+const serialBingings = require('@serialport/bindings')
 
 const defaultSecurityStrategy = './tokensecurity'
 const skPrefix = '/signalk/v1'
@@ -515,5 +516,14 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
 
   app.get('/availablePaths', (req, res, next) => {
     res.json(app.streambundle.getAvailablePaths())
+  })
+
+  app.get('/serialports', (req, res, next) => {
+    serialBingings
+      .list()
+      .then(ports => {
+        res.json(ports.map(port => port.comName))
+      })
+      .catch(next)
   })
 }

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -108,17 +108,48 @@ class TextInput extends Component {
 }
 
 class DeviceInput extends Component {
+  constructor(props) {
+    super()
+    this.state = {
+      devices: [props.value.device]
+    }
+  }
+
+  componentDidMount() {
+    fetch(`/serialports`, {
+      credentials: 'include'
+    })
+      .then(response => response.json())
+      .then(data => {
+        //make sure that the configured device is
+        //an option to be the selected on in the select,
+        //as it may be unplugged or unavailable
+        if (data.indexOf(this.props.value.device) == -1) {
+          data.push(this.props.value.device)
+        }
+        this.setState({ devices: data })
+      })
+  }
+
   render () {
     return (
-      <div>
-        <TextInput
-          title='Device'
-          name='options.device'
-          helpText='Example: /dev/ttyUSB0'
-          value={this.props.value.device}
-          onChange={this.props.onChange}
-        />
-      </div>
+      <FormGroup row>
+        <Col md='2'>
+          <Label htmlFor="serialportselect">Serial port</Label>
+        </Col>
+        <Col xs='12' md='3'>
+          <Input
+            type="select"
+            name="options.device"
+            id="serialportselect"
+            onChange={this.props.onChange}
+            value={this.props.value.device}>
+              {this.state.devices.map((device, i) => (
+                <option key={i}>{device}</option>
+              ))}
+          </Input>
+        </Col>
+      </FormGroup>
     )
   }
 }

--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -250,6 +250,7 @@ class ProvidersConfiguration extends Component {
                   <BasicProvider
                     value={this.state.selectedProvider}
                     onChange={this.handleProviderChange}
+                    key={Date.now()}
                   />
                 ) : (
                   <Input


### PR DESCRIPTION
Change the admin UI so that the user selects the
serialport device from a popup list instead of
entering it by hand. This also creates a REST
endpoint for retrieving the list of available serial
ports.

Fixes #449 