### PR TITLE
feature: command to run before opening serial ports

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "@signalk/signalk-to-nmea0183": "^1.0.0",
     "@signalk/simplegauges": "^1.0.1",
     "@signalk/zones": "^1.0.0",
+    "any-shell-escape": "^0.1.1",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.14.1",


### PR DESCRIPTION
Add the ability to run a command synchronously before opening
serial ports. This allows 'registering' serial ports that
the server uses in a managed environment.