### PR TITLE
feature: add prompt for FileStream provider data type

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -207,6 +207,7 @@ class DataTypeInput extends Component {
             name='options.dataType'
             onChange={event => this.props.onChange(event)}
           >
+            {!this.props.value.options.dataType && (<option value=''>Select data type</option>)}
             <option value='SignalK'>Signal K</option>
             <option value='NMEA2000'>NMEA 2000 (canboat)</option>
             <option value='NMEA2000JS'>NMEA 2000 (canboatjs)</option>


### PR DESCRIPTION
This adds the text 'Select data type' to FileStream provider
configuration in the hope that the user would pick one,
instead of submitting a provider without any data type.