### PR TITLE
fix: make data log path handling cross platform

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -62,9 +62,9 @@ function getFullLogDir (app, logdir) {
   if (!logdir) {
     logdir = app.config.settings.loggingDirectory || app.config.configPath
   }
-  return logdir.charAt(0) !== '/'
-    ? path.join(app.config.configPath, logdir)
-    : logdir
+  return path.isAbsolute(logdir)
+    ? logdir
+    : path.join(app.config.configPath, logdir)
 }
 
 function listLogFiles (app, cb) {


### PR DESCRIPTION
Fix things so that log path handling works on Windows as well.