### PR TITLE
Revert streambundle changes in #682 and #648

### DIFF
--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -16,7 +16,6 @@
 
 var Bacon = require('baconjs')
 const _ = require('lodash')
-const isUndefined = _.isUndefined
 
 function StreamBundle (selfId) {
   this.selfContext = 'vessels.' + selfId
@@ -50,8 +49,7 @@ StreamBundle.prototype.pushDelta = function (delta) {
                 context: delta.context,
                 source: update.source,
                 $source: update.$source,
-                timestamp: update.timestamp,
-                key: getPathWithSourceId(pathValue.path, update.$source)
+                timestamp: update.timestamp
               })
             })
           }, this)
@@ -90,14 +88,8 @@ StreamBundle.prototype.push = function (path, pathValueWithSourceAndContext) {
   }
   this.getBus(path).push(pathValueWithSourceAndContext)
   if (pathValueWithSourceAndContext.context === this.selfContext) {
-    this.getSelfBusByKey(path).push(pathValueWithSourceAndContext)
-    this.getSelfBusByKey(pathValueWithSourceAndContext.key).push(
-      pathValueWithSourceAndContext
-    )
-    this.getSelfStreamByKey(path).push(pathValueWithSourceAndContext.value)
-    this.getSelfStreamByKey(pathValueWithSourceAndContext.key).push(
-      pathValueWithSourceAndContext.value
-    )
+    this.getSelfBus(path).push(pathValueWithSourceAndContext)
+    this.getSelfStream(path).push(pathValueWithSourceAndContext.value)
   }
 }
 
@@ -110,26 +102,20 @@ StreamBundle.prototype.getBus = function (path) {
   return result
 }
 
-StreamBundle.prototype.getSelfStream = function (path, sourceId = undefined) {
-  return getSelfStreamByKey(getPathWithSourceId(path, sourceId))
+StreamBundle.prototype.getSelfStream = function (path) {
+  var result = this.streams[path]
+  if (!result) {
+    result = this.streams[path] = new Bacon.Bus()
+  }
+  return result
 }
 
-StreamBundle.prototype.getSelfStreamByKey = function (pathWithSourceId) {
-  return (
-    this.streams[pathWithSourceId] ||
-    (this.streams[pathWithSourceId] = new Bacon.Bus())
-  )
-}
-
-StreamBundle.prototype.getSelfBus = function (path, sourceId = undefined) {
-  return this.getSelfBusByKey(getPathWithSourceId(path, sourceId))
-}
-
-StreamBundle.prototype.getSelfBusByKey = function (pathWithSourceId) {
-  return (
-    this.selfBuses[pathWithSourceId] ||
-    (this.selfBuses[pathWithSourceId] = new Bacon.Bus())
-  )
+StreamBundle.prototype.getSelfBus = function (path) {
+  var result = this.selfBuses[path]
+  if (!result) {
+    result = this.selfBuses[path] = new Bacon.Bus()
+  }
+  return result
 }
 
 StreamBundle.prototype.getAvailablePaths = function () {
@@ -154,8 +140,5 @@ function toDelta (normalizedDeltaData) {
     ]
   }
 }
-
-const getPathWithSourceId = (path, sourceId) =>
-  path + (isUndefined(sourceId) ? '' : `.${sourceId}`)
 
 module.exports = { StreamBundle, toDelta }

--- a/lib/streambundle.js
+++ b/lib/streambundle.js
@@ -111,7 +111,7 @@ StreamBundle.prototype.getBus = function (path) {
 }
 
 StreamBundle.prototype.getSelfStream = function (path, sourceId = undefined) {
-  return this.getSelfStreamByKey(getPathWithSourceId(path, sourceId))
+  return getSelfStreamByKey(getPathWithSourceId(path, sourceId))
 }
 
 StreamBundle.prototype.getSelfStreamByKey = function (pathWithSourceId) {


### PR DESCRIPTION
Plugins like aisreporter use pattern
[path1, path2].map(getSelfStream)
where the array index becomes the second parameter, so
simply adding another optional parameter will
not work.