### PR TITLE
Spec compliant history paths

### DIFF
--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -21,6 +21,8 @@ const ports = require('../ports')
 const geolib = require('geolib')
 const _ = require('lodash')
 
+const iso8601rexexp = /^(-?(?:[1-9][0-9]*)?[0-9]{4})-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\.[0-9]+)?Z$/
+
 module.exports = function (app) {
   'use strict'
 
@@ -93,25 +95,36 @@ module.exports = function (app) {
           return res.json(last)
         }
 
-        if (req.query.time) {
-          if (!app.historyProvider) {
-            res.status(404).send('No history provider')
+        if (path[0] && path[0] === 'snapshot') {
+          if (!req.query.time) {
+            res.status(400).send('Snapshot api requires time query parameter')
           } else {
-            app.historyProvider.getHistory(
-              new Date(req.query.time),
-              path,
-              deltas => {
-                if (deltas.length === 0) {
-                  res.status(404).send('No data found for the given time')
-                  return
-                }
-                var last = app.deltaCache.buildFullFromDeltas(
-                  req.skPrincipal,
-                  deltas
+            if (!iso8601rexexp.test(req.query.time)) {
+              res
+                .status(400)
+                .send(
+                  'Time query parameter must be a valid ISO 8601 UTC time value like 2018-12-11T18:40:03.246'
                 )
-                sendResult(last, path)
-              }
-            )
+            } else if (!app.historyProvider) {
+              res.status(501).send('No history provider')
+            } else {
+              const realPath = path.slice(1)
+              app.historyProvider.getHistory(
+                new Date(req.query.time),
+                realPath,
+                deltas => {
+                  if (deltas.length === 0) {
+                    res.status(404).send('No data found for the given time')
+                    return
+                  }
+                  var last = app.deltaCache.buildFullFromDeltas(
+                    req.skPrincipal,
+                    deltas
+                  )
+                  sendResult(last, realPath)
+                }
+              )
+            }
           }
         } else {
           var last = app.deltaCache.buildFull(req.skPrincipal, path)

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -169,14 +169,8 @@ module.exports = function (app) {
           handleWsSubscribe(app, unsubscribes, spark, msg)
         }
 
-        if (
-          msg.unsubscribe &&
-          msg.context === '*' &&
-          msg.unsubscribe[0].path === '*'
-        ) {
-          debug('Unsubscribe all')
-          unsubscribes.forEach(unsubscribe => unsubscribe())
-          app.signalk.removeListener('delta', onChange)
+        if (msg.unsubscribe) {
+          handleWsUnsubscribe(app, unsubscribes, msg)
         }
 
         if (msg.accessRequest) {
@@ -543,4 +537,16 @@ function handleWsSubscribe (app, unsubscribes, spark, msg) {
     },
     spark.request.skPrincipal
   )
+}
+
+function handleWsUnsubscribe (app, unsubscribes, msg) {
+  if (
+    msg.unsubscribe &&
+    msg.context === '*' &&
+    msg.unsubscribe[0].path === '*'
+  ) {
+    debug('Unsubscribe all')
+    unsubscribes.forEach(unsubscribe => unsubscribe())
+    app.signalk.removeListener('delta', onChange)
+  }
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -144,11 +144,7 @@ module.exports = function (app) {
     primus.on('connection', function (spark) {
       debug(spark.id + ' connected with params ' + JSON.stringify(spark.query))
 
-      var onChange = function (data) {
-        spark.write(data)
-      }
-
-      var aclFilter = delta => {
+      let onChange = delta => {
         var filtered = app.securityStrategy.filterReadDelta(
           spark.request.skPrincipal,
           delta
@@ -157,8 +153,6 @@ module.exports = function (app) {
           spark.write(filtered)
         }
       }
-
-      onChange = aclFilter
 
       var unsubscribes = []
 
@@ -272,9 +266,10 @@ module.exports = function (app) {
       })
 
       if (!spark.query.subscribe || spark.query.subscribe === 'self') {
+        const realOnChange = onChange
         onChange = function (msg) {
           if (!msg.context || msg.context === app.selfContext) {
-            aclFilter(msg)
+            realOnChange(msg)
           }
         }
       }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -549,11 +549,10 @@ function sendLatestDeltas (deltaCache, selfContext, spark) {
 }
 
 function startServerEvents (app, spark) {
-  const boundWrite = spark.write.bind(spark)
   const onServerEvent = wrapWithverifyWS(
     app.securityStrategy,
     spark,
-    boundWrite
+    spark.write.bind(spark)
   )
   app.on('serverevent', onServerEvent)
   spark.onDisconnects.push(() => {

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -21,19 +21,18 @@ const { getSourceId } = require('@signalk/signalk-schema')
 const { requestAccess, InvalidTokenError } = require('../security')
 const { findRequest, updateRequest } = require('../requestResponse')
 const { putPath } = require('../put')
+const debug = require('debug')('signalk-server:interfaces:ws')
+const Primus = require('primus')
 
-var supportedQuerySubscribeValues = ['self', 'all']
+const supportedQuerySubscribeValues = ['self', 'all']
 
 module.exports = function (app) {
   'use strict'
 
-  var _ = require('lodash'),
-    debug = require('debug')('signalk-server:interfaces:ws'),
-    Primus = require('primus'),
-    api = {},
-    started = false,
-    primus,
-    pathSources = {}
+  const api = {}
+  let started = false
+  let primus
+  const pathSources = {}
 
   api.mdns = {
     name: app.config.settings.ssl ? '_signalk-wss' : '_signalk-ws',

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -138,30 +138,7 @@ module.exports = function (app) {
     primus = new Primus(app.server, primusOptions)
 
     if (app.securityStrategy.canAuthorizeWS()) {
-      primus.authorize(function (req, authorized) {
-        try {
-          // can't do primus.use for cookies because it will come after authorized
-          if (req.headers.cookie) {
-            req.cookies = cookie.parse(req.headers.cookie)
-          }
-
-          app.securityStrategy.authorizeWS(req)
-          authorized()
-
-          var identifier = _.get(req, 'skPrincipal.identifier')
-          if (identifier) {
-            debug(`authorized username: ${identifier}`)
-            req.source = 'ws.' + identifier.replace(/\./g, '_')
-          }
-        } catch (error) {
-          // console.error(error)
-          if (error instanceof InvalidTokenError) {
-            authorized(error)
-          } else {
-            authorized()
-          }
-        }
-      })
+      primus.authorize(createPrimusAuthorize(app.securityStrategy.authorizeWS))
     }
 
     primus.on('connection', function (spark) {
@@ -536,4 +513,33 @@ function normalizeUpdate (update) {
       values: [value]
     }
   })
+}
+
+function createPrimusAuthorize (authorizeWS) {
+  return function (req, authorized) {
+    try {
+      // can't do primus.use for cookies because it will come after authorized
+      if (req.headers.cookie) {
+        req.cookies = cookie.parse(req.headers.cookie)
+      }
+
+      authorizeWS(req)
+      authorized()
+
+      const identifier = _.get(req, 'skPrincipal.identifier')
+      if (identifier) {
+        debug(`authorized username: ${identifier}`)
+        req.source = 'ws.' + identifier.replace(/\./g, '_')
+      }
+    } catch (error) {
+      // To be able to login or request access via WS with security in place
+      // only clearly invalid tokens result in 401 response, so that we can inform
+      // the client that the credentials do not work.
+      if (error instanceof InvalidTokenError) {
+        authorized(error)
+      } else {
+        authorized()
+      }
+    }
+  }
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -30,8 +30,7 @@ module.exports = function (app) {
   'use strict'
 
   const api = {}
-  let started = false
-  let primus
+  let primuses = []
   const pathSources = {}
 
   api.mdns = {
@@ -42,9 +41,11 @@ module.exports = function (app) {
 
   api.numClients = function () {
     var count = 0
-    primus.forEach((spark, id, connections) => {
-      count++
-    })
+    primuses.forEach(primus =>
+      primus.forEach((spark, id, connections) => {
+        count++
+      })
+    )
     return count
   }
 
@@ -118,128 +119,159 @@ module.exports = function (app) {
   api.start = function () {
     debug('Starting Primus/WS interface')
 
-    started = true
-
-    const baseOptions = app.config.settings.wsCompression
-      ? {
+    let baseOptions = {
+      transformer: 'websockets',
+      pingInterval: false
+    }
+    if (app.config.settings.wsCompression) {
+      baseOptions = {
+        ...baseOptions,
         compression: true,
         transport: {
           perMessageDeflate: { threshold: 0 }
         }
       }
-      : {}
-    const primusOptions = {
-      ...baseOptions,
-      transformer: 'websockets',
-      pathname: '/signalk/v1/stream',
-      pingInterval: false
     }
 
-    primus = new Primus(app.server, primusOptions)
+    const allWsOptions = [
+      {
+        ...baseOptions,
+        pathname: '/signalk/v1/stream',
+        isPlayback: false
+      },
+      {
+        ...baseOptions,
+        pathname: '/signalk/v1/playback',
+        isPlayback: true
+      }
+    ]
 
-    if (app.securityStrategy.canAuthorizeWS()) {
-      primus.authorize(createPrimusAuthorize(app.securityStrategy.authorizeWS))
-    }
+    primuses = allWsOptions.map(primusOptions => {
+      const primus = new Primus(app.server, primusOptions)
 
-    primus.on('connection', function (spark) {
-      debug(spark.id + ' connected with params ' + JSON.stringify(spark.query))
-
-      let onChange = delta => {
-        var filtered = app.securityStrategy.filterReadDelta(
-          spark.request.skPrincipal,
-          delta
+      if (app.securityStrategy.canAuthorizeWS()) {
+        primus.authorize(
+          createPrimusAuthorize(app.securityStrategy.authorizeWS)
         )
-        if (filtered) {
-          spark.write(filtered)
-        }
       }
 
-      var unsubscribes = []
+      primus.on('connection', function (spark) {
+        debug(
+          `${spark.id} connected ${JSON.stringify(spark.query)} ${
+            primusOptions.isPlayback
+          }`
+        )
 
-      spark.on('data', function (msg) {
-        debug('<' + JSON.stringify(msg))
-        if (msg.token) {
-          spark.request.token = msg.token
-        }
-
-        if (msg.updates) {
-          processUpdates(app, pathSources, spark, msg)
-        }
-
-        if (msg.subscribe) {
-          processSubscribe(app, unsubscribes, spark, msg)
-        }
-
-        if (msg.unsubscribe) {
-          processUnsubscribe(app, unsubscribes, msg)
-        }
-
-        if (msg.accessRequest) {
-          processAccessRequest(spark, msg)
-        }
-
-        if (msg.login && app.securityStrategy.supportsLogin()) {
-          processLoginRequest(spark, msg)
-        }
-
-        if (msg.put) {
-          processPutRequest(spark, msg)
-        }
-      })
-
-      spark.on('end', function () {
-        unsubscribes.forEach(unsubscribe => unsubscribe())
-
-        _.keys(pathSources).forEach(path => {
-          _.keys(pathSources[path]).forEach(source => {
-            if (pathSources[path][source] == spark) {
-              debug('removing source for %s', path)
-              delete pathSources[path][source]
-            }
-          })
-        })
-      })
-
-      if (isSelfSubscription(spark.query)) {
-        const realOnChange = onChange
-        onChange = function (msg) {
-          if (!msg.context || msg.context === app.selfContext) {
-            realOnChange(msg)
+        let onChange = delta => {
+          var filtered = app.securityStrategy.filterReadDelta(
+            spark.request.skPrincipal,
+            delta
+          )
+          if (filtered) {
+            spark.write(filtered)
           }
         }
-      }
 
-      if (spark.query.subscribe === 'none') {
-        onChange = function () {}
-      }
+        var unsubscribes = []
 
-      onChange = wrapWithverifyWS(app.securityStrategy, spark, onChange)
+        if (primusOptions.isPlayback) {
+          spark.on('data', () => {
+            console.error('Playback does not support ws upstream messages')
+            spark.end('Playback does not support ws upstream messages')
+          })
+        } else {
+          spark.on('data', function (msg) {
+            debug('<' + JSON.stringify(msg))
+            if (msg.token) {
+              spark.request.token = msg.token
+            }
 
-      spark.onDisconnects = []
+            if (msg.updates) {
+              processUpdates(app, pathSources, spark, msg)
+            }
 
-      sendHello(app, spark)
+            if (msg.subscribe) {
+              processSubscribe(app, unsubscribes, spark, msg)
+            }
 
-      if (spark.query.startTime) {
-        handlePlaybackConnection(app, spark, onChange)
-      } else {
-        handleRealtimeConnection(app, spark, onChange)
-      }
-    })
+            if (msg.unsubscribe) {
+              processUnsubscribe(app, unsubscribes, msg)
+            }
 
-    primus.on('disconnection', function (spark) {
-      spark.onDisconnects.forEach(f => f())
-      debug(spark.id + ' disconnected')
+            if (msg.accessRequest) {
+              processAccessRequest(spark, msg)
+            }
+
+            if (msg.login && app.securityStrategy.supportsLogin()) {
+              processLoginRequest(spark, msg)
+            }
+
+            if (msg.put) {
+              processPutRequest(spark, msg)
+            }
+          })
+        }
+
+        spark.on('end', function () {
+          unsubscribes.forEach(unsubscribe => unsubscribe())
+
+          _.keys(pathSources).forEach(path => {
+            _.keys(pathSources[path]).forEach(source => {
+              if (pathSources[path][source] == spark) {
+                debug('removing source for %s', path)
+                delete pathSources[path][source]
+              }
+            })
+          })
+        })
+
+        if (isSelfSubscription(spark.query)) {
+          const realOnChange = onChange
+          onChange = function (msg) {
+            if (!msg.context || msg.context === app.selfContext) {
+              realOnChange(msg)
+            }
+          }
+        }
+
+        if (spark.query.subscribe === 'none') {
+          onChange = function () {}
+        }
+
+        onChange = wrapWithverifyWS(app.securityStrategy, spark, onChange)
+
+        spark.onDisconnects = []
+
+        if (primusOptions.isPlayback) {
+          if (!spark.query.startTime) {
+            spark.end(
+              'startTime is a required query parameter for playback connections'
+            )
+          } else {
+            handlePlaybackConnection(app, spark, onChange)
+          }
+        } else {
+          handleRealtimeConnection(app, spark, onChange)
+        }
+      })
+
+      primus.on('disconnection', function (spark) {
+        spark.onDisconnects.forEach(f => f())
+        debug(spark.id + ' disconnected')
+      })
+
+      return primus
     })
   }
 
   api.stop = function () {
-    if (primus.destroy && started) {
-      debug('Destroying primus...')
+    debug('Destroying primuses...')
+    primuses.forEach(primus =>
       primus.destroy({
         close: false,
         timeout: 500
       })
-    }
+    )
   }
 
   function processPutRequest (spark, msg) {
@@ -437,10 +469,6 @@ function processUpdates (app, pathSources, spark, msg) {
 }
 
 function processSubscribe (app, unsubscribes, spark, msg) {
-  if (spark.isHistory) {
-    spark.end('Subscribe messages not supported with history playback')
-    return
-  }
   app.subscriptionmanager.subscribe(
     msg,
     unsubscribes,
@@ -490,11 +518,11 @@ function wrapWithverifyWS (securityStrategy, spark, theFunction) {
   }
 }
 
-function sendHello (app, spark) {
+function sendHello (app, helloProps, spark) {
   spark.write({
+    ...helloProps,
     name: app.config.name,
     version: app.config.version,
-    timestamp: new Date(),
     self: `vessels.${app.selfId}`,
     roles: ['master', 'main']
   })
@@ -505,11 +533,15 @@ function handlePlaybackConnection (app, spark, onChange) {
     spark.end('No history provider')
     return
   }
+
   let options = {
     startTime: new Date(spark.query.startTime),
-    playbackRate: spark.query.playbackRate,
-    subscribe: spark.query.subscribe
+    playbackRate: spark.query.playbackRate || 1
   }
+
+  sendHello(app, options, spark)
+
+  options.subscribe = spark.query.subscribe
   app.historyProvider.hasAnyData(options, hasResults => {
     if (hasResults) {
       spark.onDisconnects.push(
@@ -523,6 +555,8 @@ function handlePlaybackConnection (app, spark, onChange) {
 }
 
 function handleRealtimeConnection (app, spark, onChange) {
+  sendHello(app, { timestamp: new Date() }, spark)
+
   app.signalk.on('delta', onChange)
   spark.onDisconnects.push(() => {
     app.signalk.removeListener('delta', onChange)

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -217,13 +217,7 @@ module.exports = function (app) {
 
       spark.onDisconnects = []
 
-      spark.write({
-        name: app.config.name,
-        version: app.config.version,
-        timestamp: new Date(),
-        self: `vessels.${app.selfId}`,
-        roles: ['master', 'main']
-      })
+      sendHello(app, spark)
 
       if (spark.query.startTime) {
         if (_.isUndefined(app.historyProvider)) {
@@ -550,4 +544,14 @@ function wrapWithverifyWS (securityStrategy, spark, theFunction) {
     }
     theFunction(msg)
   }
+}
+
+function sendHello (app, spark) {
+  spark.write({
+    name: app.config.name,
+    version: app.config.version,
+    timestamp: new Date(),
+    self: `vessels.${app.selfId}`,
+    roles: ['master', 'main']
+  })
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -162,50 +162,7 @@ module.exports = function (app) {
           spark.request.token = msg.token
         }
         if (msg.updates) {
-          if (!app.securityStrategy.shouldAllowWrite(spark.request, msg)) {
-            debug('security disallowed update')
-            app.setProviderError(
-              'ws',
-              spark.request.connection.remoteAddress + ' needs authentication'
-            )
-            return
-          }
-          app.handleMessage(spark.request.source || 'ws', msg)
-
-          msg.updates.forEach(update => {
-            var source = update['$source']
-            if (!source && update.source) {
-              source = getSourceId(update.source)
-            }
-
-            if (source) {
-              update.values.forEach(valuePath => {
-                if (!pathSources[valuePath.path]) {
-                  pathSources[valuePath.path] = {}
-                }
-                if (
-                  !pathSources[valuePath.path][source] ||
-                  pathSources[valuePath.path][source] != spark
-                ) {
-                  if (pathSources[valuePath.path][source]) {
-                    console.log(
-                      `WARNING: got a new ws client for path ${
-                        valuePath.path
-                      } source ${source}`
-                    )
-                  }
-                  debug(
-                    'registered spark for source %s path %s = %s',
-                    source,
-                    valuePath.path,
-                    spark.id
-                  )
-
-                  pathSources[valuePath.path][source] = spark
-                }
-              })
-            }
-          })
+          handleWsUpdates(app, pathSources, spark, msg)
         }
 
         if (msg.subscribe) {
@@ -537,4 +494,51 @@ function createPrimusAuthorize (authorizeWS) {
       }
     }
   }
+}
+
+function handleWsUpdates (app, pathSources, spark, msg) {
+  if (!app.securityStrategy.shouldAllowWrite(spark.request, msg)) {
+    debug('security disallowed update')
+    app.setProviderError(
+      'ws',
+      spark.request.connection.remoteAddress + ' needs authentication'
+    )
+    return
+  }
+  app.handleMessage(spark.request.source || 'ws', msg)
+
+  msg.updates.forEach(update => {
+    let source = update['$source']
+    if (!source && update.source) {
+      source = getSourceId(update.source)
+    }
+
+    if (source) {
+      update.values.forEach(valuePath => {
+        if (!pathSources[valuePath.path]) {
+          pathSources[valuePath.path] = {}
+        }
+        if (
+          !pathSources[valuePath.path][source] ||
+          pathSources[valuePath.path][source] != spark
+        ) {
+          if (pathSources[valuePath.path][source]) {
+            console.log(
+              `WARNING: got a new ws client for path ${
+                valuePath.path
+              } source ${source}`
+            )
+          }
+          debug(
+            'registered spark for source %s path %s = %s',
+            source,
+            valuePath.path,
+            spark.id
+          )
+
+          pathSources[valuePath.path][source] = spark
+        }
+      })
+    }
+  })
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -200,7 +200,7 @@ module.exports = function (app) {
         })
       })
 
-      if (!spark.query.subscribe || spark.query.subscribe === 'self') {
+      if (isSelfSubscription(spark.query)) {
         const realOnChange = onChange
         onChange = function (msg) {
           if (!msg.context || msg.context === app.selfContext) {
@@ -209,7 +209,7 @@ module.exports = function (app) {
         }
       }
 
-      if (spark.query.subscribe && spark.query.subscribe === 'none') {
+      if (spark.query.subscribe === 'none') {
         onChange = function () {}
       }
 
@@ -551,3 +551,6 @@ function processUnsubscribe (app, unsubscribes, msg) {
     app.signalk.removeListener('delta', onChange)
   }
 }
+
+const isSelfSubscription = query =>
+  !query.subscribe || query.subscribe === 'self'

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -166,26 +166,9 @@ module.exports = function (app) {
         }
 
         if (msg.subscribe) {
-          if (spark.isHistory) {
-            spark.end('Subscribe messages not supported with history playback')
-            return
-          }
-          app.subscriptionmanager.subscribe(
-            msg,
-            unsubscribes,
-            spark.write.bind(this),
-            msg => {
-              var filtered = app.securityStrategy.filterReadDelta(
-                spark.request,
-                msg
-              )
-              if (filtered) {
-                spark.write(filtered)
-              }
-            },
-            spark.request.skPrincipal
-          )
+          handleWsSubscribe(app, unsubscribes, spark, msg)
         }
+
         if (
           msg.unsubscribe &&
           msg.context === '*' &&
@@ -541,4 +524,23 @@ function handleWsUpdates (app, pathSources, spark, msg) {
       })
     }
   })
+}
+
+function handleWsSubscribe (app, unsubscribes, spark, msg) {
+  if (spark.isHistory) {
+    spark.end('Subscribe messages not supported with history playback')
+    return
+  }
+  app.subscriptionmanager.subscribe(
+    msg,
+    unsubscribes,
+    spark.write.bind(this),
+    msg => {
+      var filtered = app.securityStrategy.filterReadDelta(spark.request, msg)
+      if (filtered) {
+        spark.write(filtered)
+      }
+    },
+    spark.request.skPrincipal
+  )
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -120,19 +120,19 @@ module.exports = function (app) {
 
     started = true
 
-    const primusOptions = {
-      transformer: 'websockets',
-      pathname: '/signalk/v1/stream',
-      pingInterval: false
-    }
-
-    if (app.config.settings.wsCompression) {
-      Object.assign(primusOptions, {
+    const baseOptions = app.config.settings.wsCompression
+      ? {
         compression: true,
         transport: {
           perMessageDeflate: { threshold: 0 }
         }
-      })
+      }
+      : {}
+    const primusOptions = {
+      ...baseOptions,
+      transformer: 'websockets',
+      pathname: '/signalk/v1/stream',
+      pingInterval: false
     }
 
     primus = new Primus(app.server, primusOptions)

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-var flatMap = require('flatmap')
+const flatMap = require('flatmap')
 const _ = require('lodash')
 const ports = require('../ports')
 const cookie = require('cookie')
@@ -220,65 +220,9 @@ module.exports = function (app) {
       sendHello(app, spark)
 
       if (spark.query.startTime) {
-        if (_.isUndefined(app.historyProvider)) {
-          spark.end('No history provider')
-          return
-        }
-        let options = {
-          startTime: new Date(spark.query.startTime),
-          playbackRate: spark.query.playbackRate,
-          subscribe: spark.query.subscribe
-        }
-        app.historyProvider.hasAnyData(options, hasResults => {
-          if (hasResults) {
-            spark.onDisconnects.push(
-              app.historyProvider.streamHistory(spark, options, onChange)
-            )
-            spark.isHistory = true
-          } else {
-            spark.end('No data found')
-          }
-        })
+        handlePlaybackConnection(app, spark, onChange)
       } else {
-        app.signalk.on('delta', onChange)
-        spark.onDisconnects.push(() => {
-          app.signalk.removeListener('delta', onChange)
-        })
-
-        const boundWrite = spark.write.bind(spark)
-        if (!spark.query.subscribe || spark.query.subscribe === 'self') {
-          app.deltaCache
-            .getCachedDeltas(
-              spark.request.skPrincipal,
-              delta => delta.context === app.selfContext
-            )
-            .forEach(delta => spark.write(delta))
-        } else if (spark.query.subscribe === 'all') {
-          app.deltaCache
-            .getCachedDeltas(spark.request.skPrincipal, delta => true)
-            .forEach(boundWrite)
-        }
-
-        if (spark.query.serverevents && spark.query.serverevents === 'all') {
-          const onServerEvent = wrapWithverifyWS(
-            app.securityStrategy,
-            spark,
-            boundWrite
-          )
-          app.on('serverevent', onServerEvent)
-          spark.onDisconnects.push(() => {
-            app.removeListener('serverevent', onServerEvent)
-          })
-          Object.keys(app.lastServerEvents).forEach(propName => {
-            spark.write(app.lastServerEvents[propName])
-          })
-          if (app.securityStrategy.canAuthorizeWS()) {
-            spark.write({
-              type: 'RECEIVE_LOGIN_STATUS',
-              data: app.securityStrategy.getLoginStatus(spark.request)
-            })
-          }
-        }
+        handleRealtimeConnection(app, spark, onChange)
       }
     })
 
@@ -554,4 +498,77 @@ function sendHello (app, spark) {
     self: `vessels.${app.selfId}`,
     roles: ['master', 'main']
   })
+}
+
+function handlePlaybackConnection (app, spark, onChange) {
+  if (_.isUndefined(app.historyProvider)) {
+    spark.end('No history provider')
+    return
+  }
+  let options = {
+    startTime: new Date(spark.query.startTime),
+    playbackRate: spark.query.playbackRate,
+    subscribe: spark.query.subscribe
+  }
+  app.historyProvider.hasAnyData(options, hasResults => {
+    if (hasResults) {
+      spark.onDisconnects.push(
+        app.historyProvider.streamHistory(spark, options, onChange)
+      )
+      spark.isHistory = true
+    } else {
+      spark.end('No data found')
+    }
+  })
+}
+
+function handleRealtimeConnection (app, spark, onChange) {
+  app.signalk.on('delta', onChange)
+  spark.onDisconnects.push(() => {
+    app.signalk.removeListener('delta', onChange)
+  })
+
+  sendLatestDeltas(app.deltaCache, app.selfContext, spark)
+
+  if (spark.query.serverevents === 'all') {
+    startServerEvents(app, spark)
+  }
+}
+
+function sendLatestDeltas (deltaCache, selfContext, spark) {
+  const boundWrite = spark.write.bind(spark)
+  if (!spark.query.subscribe || spark.query.subscribe === 'self') {
+    deltaCache
+      .getCachedDeltas(
+        spark.request.skPrincipal,
+        delta => delta.context === selfContext
+      )
+      .forEach(delta => spark.write(delta))
+  } else if (spark.query.subscribe === 'all') {
+    deltaCache
+      .getCachedDeltas(spark.request.skPrincipal, delta => true)
+      .forEach(boundWrite)
+  }
+}
+
+function startServerEvents (app, spark) {
+  const boundWrite = spark.write.bind(spark)
+  const onServerEvent = wrapWithverifyWS(
+    app.securityStrategy,
+    spark,
+    boundWrite
+  )
+  app.on('serverevent', onServerEvent)
+  spark.onDisconnects.push(() => {
+    app.removeListener('serverevent', onServerEvent)
+  })
+  Object.keys(app.lastServerEvents).forEach(propName => {
+    spark.write(app.lastServerEvents[propName])
+  })
+  if (app.securityStrategy.canAuthorizeWS()) {
+    spark.write({
+      type: 'RECEIVE_LOGIN_STATUS',
+      data: app.securityStrategy.getLoginStatus(spark.request)
+    })
+  }
 }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -161,16 +161,17 @@ module.exports = function (app) {
         if (msg.token) {
           spark.request.token = msg.token
         }
+
         if (msg.updates) {
-          handleWsUpdates(app, pathSources, spark, msg)
+          processUpdates(app, pathSources, spark, msg)
         }
 
         if (msg.subscribe) {
-          handleWsSubscribe(app, unsubscribes, spark, msg)
+          processSubscribe(app, unsubscribes, spark, msg)
         }
 
         if (msg.unsubscribe) {
-          handleWsUnsubscribe(app, unsubscribes, msg)
+          processUnsubscribe(app, unsubscribes, msg)
         }
 
         if (msg.accessRequest) {
@@ -473,7 +474,7 @@ function createPrimusAuthorize (authorizeWS) {
   }
 }
 
-function handleWsUpdates (app, pathSources, spark, msg) {
+function processUpdates (app, pathSources, spark, msg) {
   if (!app.securityStrategy.shouldAllowWrite(spark.request, msg)) {
     debug('security disallowed update')
     app.setProviderError(
@@ -520,7 +521,7 @@ function handleWsUpdates (app, pathSources, spark, msg) {
   })
 }
 
-function handleWsSubscribe (app, unsubscribes, spark, msg) {
+function processSubscribe (app, unsubscribes, spark, msg) {
   if (spark.isHistory) {
     spark.end('Subscribe messages not supported with history playback')
     return
@@ -539,7 +540,7 @@ function handleWsSubscribe (app, unsubscribes, spark, msg) {
   )
 }
 
-function handleWsUnsubscribe (app, unsubscribes, msg) {
+function processUnsubscribe (app, unsubscribes, msg) {
   if (
     msg.unsubscribe &&
     msg.context === '*' &&

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -216,9 +216,6 @@ module.exports = function (app) {
       onChange = wrapWithverifyWS(app.securityStrategy, spark, onChange)
 
       spark.onDisconnects = []
-      spark.onDisconnect = function () {
-        spark.onDisconnects.forEach(f => f())
-      }
 
       spark.write({
         name: app.config.name,
@@ -240,12 +237,9 @@ module.exports = function (app) {
         }
         app.historyProvider.hasAnyData(options, hasResults => {
           if (hasResults) {
-            const onDisconnect = app.historyProvider.streamHistory(
-              spark,
-              options,
-              onChange
+            spark.onDisconnects.push(
+              app.historyProvider.streamHistory(spark, options, onChange)
             )
-            spark.onDisconnects = [onDisconnect]
             spark.isHistory = true
           } else {
             spark.end('No data found')
@@ -253,11 +247,9 @@ module.exports = function (app) {
         })
       } else {
         app.signalk.on('delta', onChange)
-        spark.onDisconnects = [
-          () => {
-            app.signalk.removeListener('delta', onChange)
-          }
-        ]
+        spark.onDisconnects.push(() => {
+          app.signalk.removeListener('delta', onChange)
+        })
 
         const boundWrite = spark.write.bind(spark)
         if (!spark.query.subscribe || spark.query.subscribe === 'self') {
@@ -294,29 +286,10 @@ module.exports = function (app) {
           }
         }
       }
-      function wrapWithverifyWS (theFunction) {
-        if (!app.securityStrategy.canAuthorizeWS()) {
-          return theFunction
-        }
-        return msg => {
-          try {
-            app.securityStrategy.verifyWS(spark.request)
-          } catch (error) {
-            if (!spark.skPendingAccessRequest) {
-              spark.end(
-                '{message: "Connection disconnected by security constraint"}',
-                { reconnect: true }
-              )
-            }
-            return
-          }
-          theFunction(msg)
-        }
-      }
     })
 
     primus.on('disconnection', function (spark) {
-      spark.onDisconnect()
+      spark.onDisconnects.forEach(f => f())
       debug(spark.id + ' disconnected')
     })
   }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -213,7 +213,7 @@ module.exports = function (app) {
         onChange = function () {}
       }
 
-      onChange = wrapWithverifyWS(onChange)
+      onChange = wrapWithverifyWS(app.securityStrategy, spark, onChange)
 
       spark.onDisconnects = []
       spark.onDisconnect = function () {
@@ -274,7 +274,11 @@ module.exports = function (app) {
         }
 
         if (spark.query.serverevents && spark.query.serverevents === 'all') {
-          const onServerEvent = wrapWithverifyWS(boundWrite)
+          const onServerEvent = wrapWithverifyWS(
+            app.securityStrategy,
+            spark,
+            boundWrite
+          )
           app.on('serverevent', onServerEvent)
           spark.onDisconnects.push(() => {
             app.removeListener('serverevent', onServerEvent)
@@ -554,3 +558,23 @@ function processUnsubscribe (app, unsubscribes, msg) {
 
 const isSelfSubscription = query =>
   !query.subscribe || query.subscribe === 'self'
+
+function wrapWithverifyWS (securityStrategy, spark, theFunction) {
+  if (!securityStrategy.canAuthorizeWS()) {
+    return theFunction
+  }
+  return msg => {
+    try {
+      securityStrategy.verifyWS(spark.request)
+    } catch (error) {
+      if (!spark.skPendingAccessRequest) {
+        spark.end(
+          '{message: "Connection disconnected by security constraint"}',
+          { reconnect: true }
+        )
+      }
+      return
+    }
+    theFunction(msg)
+  }
+}

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -536,19 +536,16 @@ function handleRealtimeConnection (app, spark, onChange) {
 }
 
 function sendLatestDeltas (deltaCache, selfContext, spark) {
-  const boundWrite = spark.write.bind(spark)
+  let deltaFilter = delta => false
   if (!spark.query.subscribe || spark.query.subscribe === 'self') {
-    deltaCache
-      .getCachedDeltas(
-        spark.request.skPrincipal,
-        delta => delta.context === selfContext
-      )
-      .forEach(delta => spark.write(delta))
+    deltaFilter = delta => delta.context === selfContext
   } else if (spark.query.subscribe === 'all') {
-    deltaCache
-      .getCachedDeltas(spark.request.skPrincipal, delta => true)
-      .forEach(boundWrite)
+    deltaFilter = delta => true
   }
+
+  deltaCache
+    .getCachedDeltas(spark.request.skPrincipal, deltaFilter)
+    .forEach(spark.write, spark)
 }
 
 function startServerEvents (app, spark) {

--- a/test/history.js
+++ b/test/history.js
@@ -73,7 +73,7 @@ describe('History', _ => {
 
   it('startTime subscription works', async function () {
     var wsPromiser = new WsPromiser(
-      `ws://0.0.0.0:${port}/signalk/v1/stream?subscribe=self&startTime=2018-08-09T14:07:29.695Z`
+      `ws://0.0.0.0:${port}/signalk/v1/playback?subscribe=self&startTime=2018-08-09T14:07:29.695Z`
     )
     var msg = await wsPromiser.nextMsg()
     msg.should.not.equal('timeout')

--- a/test/history.js
+++ b/test/history.js
@@ -90,7 +90,7 @@ describe('History', _ => {
 
   it('REST time request works', async function () {
     var result = await fetch(
-      `${url}/signalk/v1/api/vessels/self?time=2018-08-09T14:07:29.695Z`
+      `${url}/signalk/v1/api/snapshot/vessels/self?time=2018-08-09T14:07:29.695Z`
     )
     result.status.should.equal(200)
     var json = await result.json()
@@ -99,7 +99,7 @@ describe('History', _ => {
 
   it('REST time request with no data  works', async function () {
     var result = await fetch(
-      `${url}/signalk/v1/api/vessels/self?time=2018-08-09T14:07:29.694Z`
+      `${url}/signalk/v1/api/snapshot/vessels/self?time=2018-08-09T14:07:29.694Z`
     )
     result.status.should.equal(404)
   })


### PR DESCRIPTION
The [snapshot](https://signalk.org/specification/1.3.0/doc/rest_api.html#history-snapshot-retrieval) and [playback](https://signalk.org/specification/1.3.0/doc/streaming_api.html#history-playback) endpoints were changed in the process of adding these features to the specification from the original implementation in the server.

This PR changes the features to be spec compliant as two separate endpoints.

The changes are pretty heavy in ws.js, which had grown pretty unwieldy. I have tried to make its structure more sensible. The basic idea is that we now create several Primus instances, which share a lot of the functionalities related to for example security, but implement their core differently.