### PR TITLE
fix: provider fields losing focus

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ProvidersConfiguration.js
@@ -250,7 +250,6 @@ class ProvidersConfiguration extends Component {
                   <BasicProvider
                     value={this.state.selectedProvider}
                     onChange={this.handleProviderChange}
-                    key={Date.now()}
                   />
                 ) : (
                   <Input


### PR DESCRIPTION
Subcomponents, like form text fields, are losing focus
because after every keystroke the form is rendered anew.
Remove accidentally(?) added timestamp key property from
the container.