### PR TITLE
refactor: Establish config dir with getConfigDirectory. Logic tested

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -133,23 +133,30 @@ function checkPackageVersion (name, pkg) {
   }
 }
 
-function setConfigDirectory (app) {
-  if (process.env.SIGNALK_NODE_CONDFIG_DIR) {
-    app.config.configPath = path.resolve(process.env.SIGNALK_NODE_CONDFIG_DIR)
-  } else if (process.env.SIGNALK_NODE_CONFIG_DIR) {
-    app.config.configPath = path.resolve(process.env.SIGNALK_NODE_CONFIG_DIR)
-  } else if (!app.argv.c && !app.argv.s && process.env.HOME) {
-    app.config.configPath = path.join(process.env.HOME, '.signalk')
-    console.log(`Using default configuration path: ${app.config.configPath}`)
+// Establish what the config directory path is.
+function getConfigDirectory ({ argv, config, env }) {
+  const configPaths = [
+    env.SIGNALK_NODE_CONDFIG_DIR,
+    env.SIGNALK_NODE_CONFIG_DIR,
+    config.configPath,
+    argv.c,
+    env.HOME && path.join(env.HOME, '.signalk'),
+    config.appPath
+  ]
+  // Find first config directory path that has a value.
+  const configPath = path.resolve(_.find(configPaths))
+  debug('configDirPath: ' + configPath)
+  return configPath
+}
 
+// Create directories and set app.config.configPath.
+function setConfigDirectory (app) {
+  app.config.configPath = getConfigDirectory(app)
+  if (app.config.configPath !== app.config.appPath) {
     if (!fs.existsSync(app.config.configPath)) {
       fs.mkdirSync(app.config.configPath)
+      debug(`configDir Created: ${app.config.configPath}`)
     }
-  } else {
-    app.config.configPath = app.argv.c || app.config.appPath
-  }
-
-  if (app.config.configPath != app.config.appPath) {
     var configPackage = path.join(app.config.configPath, 'package.json')
     if (!fs.existsSync(configPackage)) {
       fs.writeFileSync(
@@ -334,8 +341,9 @@ const pluginsPackageJsonTemplate = {
 }
 
 module.exports = {
-  load: load,
-  writeSettingsFile: writeSettingsFile,
-  writeDefaultsFile: writeDefaultsFile,
-  readDefaultsFile: readDefaultsFile
+  load,
+  getConfigDirectory,
+  writeSettingsFile,
+  writeDefaultsFile,
+  readDefaultsFile
 }

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -135,6 +135,7 @@ function checkPackageVersion (name, pkg) {
 
 // Establish what the config directory path is.
 function getConfigDirectory ({ argv, config, env }) {
+  // Possible paths in order of priority.
   const configPaths = [
     env.SIGNALK_NODE_CONDFIG_DIR,
     env.SIGNALK_NODE_CONFIG_DIR,
@@ -143,7 +144,7 @@ function getConfigDirectory ({ argv, config, env }) {
     env.HOME && path.join(env.HOME, '.signalk'),
     config.appPath
   ]
-  // Find first config directory path that has a value.
+  // Find first config directory path that has a truthy value.
   const configPath = path.resolve(_.find(configPaths))
   debug('configDirPath: ' + configPath)
   return configPath
@@ -157,18 +158,18 @@ function setConfigDirectory (app) {
       fs.mkdirSync(app.config.configPath)
       debug(`configDir Created: ${app.config.configPath}`)
     }
-    var configPackage = path.join(app.config.configPath, 'package.json')
+    const configPackage = path.join(app.config.configPath, 'package.json')
     if (!fs.existsSync(configPackage)) {
       fs.writeFileSync(
         configPackage,
         JSON.stringify(pluginsPackageJsonTemplate, null, 2)
       )
     }
-    let npmrcPath = path.join(app.config.configPath, '.npmrc')
+    const npmrcPath = path.join(app.config.configPath, '.npmrc')
     if (!fs.existsSync(npmrcPath)) {
       fs.writeFileSync(npmrcPath, 'package-lock=false\n')
     } else {
-      let contents = fs.readFileSync(npmrcPath)
+      const contents = fs.readFileSync(npmrcPath)
       if (contents.indexOf('package-lock=') == -1) {
         fs.appendFileSync(npmrcPath, '\npackage-lock=false\n')
       }

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -1,0 +1,34 @@
+const { expect } = require('chai')
+const { getConfigDirectory } = require('./config')
+const { appPath } = require('./get')
+
+const app = {
+  argv: {},
+  config: {
+    appPath: '/var/node/signalk',
+    configPath: '/data/signalk-config'
+  },
+  env: {
+    HOME: '/user/foo',
+    SIGNALK_NODE_CONFIG_DIR: '/data/signalk/config'
+  }
+}
+
+describe('getConfigDirectory', () => {
+  it('Allow env to overwrite constructor configPath setting.', () => {
+    expect(getConfigDirectory(app)).to.equal('/data/signalk/config')
+  })
+  it('Constructor configPath has priority when no env SK Config Dir.', () => {
+    delete app.env.SIGNALK_NODE_CONFIG_DIR
+    expect(getConfigDirectory(app)).to.equal('/data/signalk-config')
+  })
+  it('No config setting then defaults to user dir.', () => {
+    delete app.config.configPath
+    expect(getConfigDirectory(app)).to.equal('/user/foo/.signalk')
+  })
+  it('Use the node process dir `appPath` as last resort.', () => {
+    delete app.config.configPath
+    delete app.env.HOME
+    expect(getConfigDirectory(app)).to.equal('/var/node/signalk')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "changelog": "github-changes -o signalk -r signalk-server-node -a --only-pulls --use-commit-body --data=pulls  --tag-name=v$npm_package_version",
     "release": "git tag -d v$npm_package_version ; npm run changelog && git add CHANGELOG.md && git commit -m 'chore: update changelog' && git tag v$npm_package_version && git push --tags && git push && git tag -d latest && git push origin :refs/tags/latest && git tag latest && git push origin tag latest",
     "start": "node bin/signalk-server",
-    "test": "mocha --exit",
+    "test": "npm run test-lib && mocha --exit",
     "test-lib": "mocha $(find lib -name '*test.js')",
     "format": "prettier-standard lib/**/*.js* providers/*.js* test/*.js* index.js",
     "heroku-postbuild": "npm install @signalk/simple-gpx"


### PR DESCRIPTION
This is extracted from my failed pr #595. I am going to make smaller PRs for easier discussion.

The purpose is to make the logic that decides `app.config.configPath` easier to reason about and in its own testable function. It also helps isolate the side effect functionality of `setConfigDirectory()`.

New function `getConfigDirectory()` creates an array of possible paths in order of priority. We use [_.find](https://lodash.com/docs/4.17.11#find) to find the first truthy path value. I decided to put everything in an array so that it's easy to do a `console.log` or `debug` all available options. It's also easier to understand the priority.

A `npm run lib-test` is added to demonstrate its functionality.

I also make a couple style changes like switching `let` to `const`.

[edit]: `setConfigDirectory` could be renamed to something like `createConfigFiles`.