### PR TITLE
refactor: disableWriteSettings should be instance specific. Not global.

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -57,10 +57,15 @@ function load (app) {
     'disableWriteSettings',
     !_.isEmpty(config.settings)
   )
-  if (config.disableWriteSettings) {
+  const defaultSettings = { interfaces: {}, pipedProviders: [] }
+  app.config.settings = _.merge(
+    defaultSettings,
+    readSettingsFile(app),
+    app.config.settings || {}
+  )
+  if (!config.disableWriteSettings) {
     debug('Using settings from constructor call, not reading defaults')
   } else {
-    readSettingsFile(app)
     setFullDefaults(app)
   }
   setSelfSettings(app)
@@ -263,20 +268,19 @@ function setSelfSettings (app) {
 }
 
 function readSettingsFile (app) {
-  const settings = getSettingsFilename(app)
-  if (!app.argv.s && !fs.existsSync(settings)) {
-    console.log('Settings file does not exist, using empty settings')
-    app.config.settings = {}
-  } else {
-    debug('Using settings file: ' + settings)
-    app.config.settings = require(settings)
+  const filename = getSettingsFilename(app)
+  if (app.config.disableWriteSettings) {
+    debug(
+      'Constructor contained settings. Set `config.disableWriteSettings: false` to merge file.'
+    )
+    return { filename: null }
   }
-  if (_.isUndefined(app.config.settings.pipedProviders)) {
-    app.config.settings.pipedProviders = []
+  if (!app.argv.s && !fs.existsSync(filename)) {
+    debug('Settings file does not exist, using empty settings.')
+    return { filename }
   }
-  if (_.isUndefined(app.config.settings.interfaces)) {
-    app.config.settings.interfaces = {}
-  }
+  debug('Using settings file: ' + filename)
+  return Object.assign({ filename }, require(filename))
 }
 
 function writeSettingsFile (app, settings, cb) {
@@ -337,8 +341,9 @@ const pluginsPackageJsonTemplate = {
 }
 
 module.exports = {
-  load: load,
-  writeSettingsFile: writeSettingsFile,
-  writeDefaultsFile: writeDefaultsFile,
-  readDefaultsFile: readDefaultsFile
+  load,
+  writeSettingsFile,
+  writeDefaultsFile,
+  readDefaultsFile,
+  readSettingsFile
 }

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -23,8 +23,6 @@ const fs = require('fs')
 const uuidv4 = require('uuid/v4')
 const semver = require('semver')
 
-var disableWriteSettings = false
-
 function load (app) {
   app.__argv = process.argv.slice(2)
   app.argv = require('minimist')(app.__argv)
@@ -53,9 +51,14 @@ function load (app) {
   config.appPath = config.appPath || path.normalize(__dirname + '/../../')
   debug('appPath:' + config.appPath)
   setConfigDirectory(app)
-  if (_.isObject(app.config.settings)) {
+  // Using _.get to enable setting a default if disableWriteSettings is undefined.
+  config.disableWriteSettings = _.get(
+    config,
+    'disableWriteSettings',
+    !_.isEmpty(config.settings)
+  )
+  if (config.disableWriteSettings) {
     debug('Using settings from constructor call, not reading defaults')
-    disableWriteSettings = true
   } else {
     readSettingsFile(app)
     setFullDefaults(app)
@@ -237,7 +240,7 @@ function setSelfSettings (app) {
   if (_.isUndefined(mmsi) && _.isUndefined(uuid)) {
     uuid = 'urn:mrn:signalk:uuid:' + uuidv4()
     _.set(app.config.defaults, 'vessels.self.uuid', uuid)
-    if (!disableWriteSettings) {
+    if (!app.config.disableWriteSettings) {
       writeDefaultsFile(app, app.config.defaults, err => {
         if (err) {
           console.error(`unable to write defaults file: ${err}`)
@@ -277,7 +280,7 @@ function readSettingsFile (app) {
 }
 
 function writeSettingsFile (app, settings, cb) {
-  if (!disableWriteSettings) {
+  if (!app.config.disableWriteSettings) {
     const settingsPath = getSettingsFilename(app)
     fs.writeFile(settingsPath, JSON.stringify(settings, null, 2), cb)
   } else {

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -1,0 +1,31 @@
+const path = require('path')
+const { expect } = require('chai')
+const { readSettingsFile } = require('./config')
+const { appPath } = require('./get')
+
+describe('readSettingsFile', () => {
+  const app = {
+    argv: {},
+    config: {
+      configPath: '/data/signalk-config'
+    }
+  }
+  it('Does not load file when disableWriteSettings.', () => {
+    app.config.disableWriteSettings = true
+    expect(readSettingsFile(app)).to.eql({ filename: null })
+  })
+  it('Tries to load file when disableWriteSetting=false.', () => {
+    app.config.disableWriteSettings = false
+    expect(readSettingsFile(app)).to.eql({
+      filename: '/data/signalk-config/settings.json'
+    })
+  })
+  it('Loads file when disableWriteSetting=false and file found.', () => {
+    app.config.disableWriteSettings = false
+    app.config.configPath = path.join(appPath, 'settings')
+    const res = readSettingsFile(app)
+    expect(res.vessel.name).to.equal('Volare')
+    expect(res.filename.endsWith('settings/settings.json')).to.equal(true)
+  })
+  console.log()
+})


### PR DESCRIPTION
Currently `disableWriteSettings` is a global value. I changed it to be within the scope of the `app` instance instead. Also, I'm allowing a manual setting of `disableWriteSettings` by including it in the `config` object when the class is instantiated.

```javascript
// Before these would all prevent the loading/saving of files.
const server = new SignalKServer({ config: { settings: { foo: 'bar' } }})
const server = new SignalKServer({ config: { settings: {} }})

// Now these options will merge settings file.
const server = new SignalKServer({ config: { settings: {} }})
const server = new SignalKServer({ config: { disableWriteSettings: false, settings: { foo: 'bar' } }})
```

This PR is extracted from my failed pr #595. In that one I had used `loadFiles` instead of `disableWriteSettings`. Since `disableWriteSettings` is what made it into the code I'm using that.