### PR TITLE
fix: Fixes #555 checkPackageVersion must use appPath.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Change Log
 
+### v1.10.1 (2018/12/17 22:42 +00:00)
+- [#688](https://github.com/SignalK/signalk-server-node/pull/688) feature: provide text box for device path entry in provider config (@sbender9)
+- [#686](https://github.com/SignalK/signalk-server-node/pull/686) fix: provider fields losing focus (@tkurki)
+- [#685](https://github.com/SignalK/signalk-server-node/pull/685) chore: default ikonvert baudrate should be 230400 (@sbender9)
+
 ### v1.10.0 (2018/12/16 21:23 +00:00)
 - [#683](https://github.com/SignalK/signalk-server-node/pull/683) Revert streambundle changes in #682 and #648 (@tkurki)
 - [#644](https://github.com/SignalK/signalk-server-node/pull/644) feature: add support for Digital Yacht’s iKonvert (@sbender9)

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -40,6 +40,7 @@ function load (app) {
   debug('appPath:' + config.appPath)
 
   try {
+    // Relative path since we need signalk-server/package.json regardless of how installed.
     const pkg = require('../../package.json')
     config.name = pkg.name
     config.author = pkg.author

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -22,6 +22,7 @@ const _ = require('lodash')
 const fs = require('fs')
 const uuidv4 = require('uuid/v4')
 const semver = require('semver')
+const { appPath, getAppModuleInfo } = require('./get')
 
 var disableWriteSettings = false
 
@@ -35,6 +36,9 @@ function load (app) {
   config.getExternalHostname = getExternalHostname.bind(config, config)
   config.getExternalPort = getExternalPort.bind(config, config)
 
+  config.appPath = config.appPath || appPath
+  debug('appPath:' + config.appPath)
+
   try {
     const pkg = require('../../package.json')
     config.name = pkg.name
@@ -42,16 +46,15 @@ function load (app) {
     config.contributors = pkg.contributors
     config.version = pkg.version
     config.description = pkg.description
+    config.dependencies = pkg.dependencies
 
-    checkPackageVersion('@signalk/server-admin-ui', pkg)
-    checkPackageVersion('@signalk/plugin-config', pkg)
+    checkPackageVersion('@signalk/server-admin-ui', app)
+    checkPackageVersion('@signalk/plugin-config', app)
   } catch (err) {
     console.error('error parsing package.json', err)
     process.exit(1)
   }
 
-  config.appPath = config.appPath || path.normalize(__dirname + '/../../')
-  debug('appPath:' + config.appPath)
   setConfigDirectory(app)
   if (_.isObject(app.config.settings)) {
     debug('Using settings from constructor call, not reading defaults')
@@ -119,9 +122,9 @@ function load (app) {
   require('./production')(app)
 }
 
-function checkPackageVersion (name, pkg) {
-  const expected = pkg.dependencies[name]
-  const installed = require(`../../node_modules/${name}/package.json`)
+function checkPackageVersion (name, app) {
+  const expected = app.config.dependencies[name]
+  const installed = require(getAppModuleInfo(name, app))
 
   if (!semver.satisfies(installed.version, expected)) {
     console.error(

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -22,7 +22,7 @@ const _ = require('lodash')
 const fs = require('fs')
 const uuidv4 = require('uuid/v4')
 const semver = require('semver')
-const { appPath, getAppModuleInfo } = require('./get')
+const { appPath, getAppPackagePath } = require('./get')
 
 var disableWriteSettings = false
 
@@ -125,7 +125,7 @@ function load (app) {
 
 function checkPackageVersion (name, app) {
   const expected = app.config.dependencies[name]
-  const installed = require(getAppModuleInfo(name, app))
+  const installed = require(getAppPackagePath(name, app))
 
   if (!semver.satisfies(installed.version, expected)) {
     console.error(

--- a/lib/config/get.js
+++ b/lib/config/get.js
@@ -10,7 +10,7 @@ const getAppPath = get('config.appPath')
 const getAppModulesPath = flow(getAppPath, addModulesPath)
 
 const getModulePath = curry((filename, moduleName, app) =>
-  flow(getAppModulesPath, partialRight(path.join, [moduleName, filename]))(app)
+  flow(getAppModulesPath, x => path.join(x, moduleName, filename))(app)
 )
 
 const getAppPackagePath = getModulePath('package.json')

--- a/lib/config/get.js
+++ b/lib/config/get.js
@@ -1,5 +1,5 @@
 const path = require('path')
-const { curry, flow, get, partialRight, unary } = require('lodash/fp')
+const { curry, flow, get, unary } = require('lodash/fp')
 
 const appPath = path.normalize(__dirname + '/../../')
 const addModulesPath = str => path.join(str, 'node_modules/')

--- a/lib/config/get.js
+++ b/lib/config/get.js
@@ -15,7 +15,7 @@ const getModulePath = curry((filename, moduleName, app) =>
 
 const getAppPackagePath = getModulePath('package.json')
 // Build path to the public dir of a module. getInstalledPathSync(moduleName, { local: true })
-const getModulePublicPathPath = getModulePath('public')
+const getModulePublicPath = getModulePath('public')
 
 module.exports = {
   addModulesPath,

--- a/lib/config/get.js
+++ b/lib/config/get.js
@@ -13,17 +13,17 @@ const getModulePath = curry((filename, moduleName, app) =>
   flow(getAppModulesPath, partialRight(path.join, [moduleName, filename]))(app)
 )
 
-const getAppModuleInfo = getModulePath('package.json')
+const getAppPackagePath = getModulePath('package.json')
 // Build path to the public dir of a module. getInstalledPathSync(moduleName, { local: true })
-const getModulePublic = getModulePath('public')
+const getModulePublicPathPath = getModulePath('public')
 
 module.exports = {
   addModulesPath,
   appModules,
   appPath,
   getAppPath,
-  getAppModuleInfo,
+  getAppPackagePath,
   getAppModulesPath,
   getModulePath,
-  getModulePublic
+  getModulePublicPath
 }

--- a/lib/config/get.js
+++ b/lib/config/get.js
@@ -1,20 +1,29 @@
 const path = require('path')
-const { flow, get, partialRight } = require('lodash/fp')
+const { curry, flow, get, partialRight, unary } = require('lodash/fp')
 
 const appPath = path.normalize(__dirname + '/../../')
-const addModules = partialRight(path.join, ['node_modules/'])
+const addModules = unary(partialRight(path.join, ['node_modules/']))
 const appModules = addModules(appPath)
 
 // Return the appPath from an app object.
 const getAppPath = get('config.appPath')
+const getAppModules = flow(getAppPath, addModules)
 
+const getModulePath = curry((filename, moduleName, app) =>
+  flow(getAppModules, partialRight(path.join, [moduleName, filename]))(app)
+)
+
+const getAppModuleInfo = getModulePath('package.json')
 // Build path to the public dir of a module. getInstalledPathSync(moduleName, { local: true })
-const getModulePublic = moduleName =>
-  flow(getAppPath, addModules, partialRight(path.join, [moduleName, 'public']))
+const getModulePublic = getModulePath('public')
 
 module.exports = {
+  addModules,
   appModules,
   appPath,
   getAppPath,
+  getAppModuleInfo,
+  getAppModules,
+  getModulePath,
   getModulePublic
 }

--- a/lib/config/get.js
+++ b/lib/config/get.js
@@ -2,12 +2,12 @@ const path = require('path')
 const { curry, flow, get, partialRight, unary } = require('lodash/fp')
 
 const appPath = path.normalize(__dirname + '/../../')
-const addModules = unary(partialRight(path.join, ['node_modules/']))
-const appModules = addModules(appPath)
+const addModulesPath = str => path.join(str, 'node_modules/')
+const appModules = addModulesPath(appPath)
 
 // Return the appPath from an app object.
 const getAppPath = get('config.appPath')
-const getAppModules = flow(getAppPath, addModules)
+const getAppModules = flow(getAppPath, addModulesPath)
 
 const getModulePath = curry((filename, moduleName, app) =>
   flow(getAppModules, partialRight(path.join, [moduleName, filename]))(app)
@@ -18,7 +18,7 @@ const getAppModuleInfo = getModulePath('package.json')
 const getModulePublic = getModulePath('public')
 
 module.exports = {
-  addModules,
+  addModulesPath,
   appModules,
   appPath,
   getAppPath,

--- a/lib/config/get.js
+++ b/lib/config/get.js
@@ -3,7 +3,7 @@ const { curry, flow, get, unary } = require('lodash/fp')
 
 const appPath = path.normalize(__dirname + '/../../')
 const addModulesPath = str => path.join(str, 'node_modules/')
-const appModules = addModulesPath(appPath)
+const appModulesPath = addModulesPath(appPath)
 
 // Return the appPath from an app object.
 const getAppPath = get('config.appPath')
@@ -19,7 +19,7 @@ const getModulePublicPath = getModulePath('public')
 
 module.exports = {
   addModulesPath,
-  appModules,
+  appModulesPath,
   appPath,
   getAppPath,
   getAppPackagePath,

--- a/lib/config/get.test.js
+++ b/lib/config/get.test.js
@@ -1,0 +1,36 @@
+const chai = require('chai')
+const {
+  getAppPath,
+  getAppModules,
+  getModulePath,
+  getModulePublic
+} = require('./get')
+
+const app = { config: { appPath: '/foo' } }
+
+describe('getAppPath', () => {
+  it('Get the appPath value from app config.', () => {
+    chai.expect(getAppPath(app)).to.equal('/foo')
+  })
+})
+describe('getAppModules', () => {
+  it('Get the appPath value from app config.', () => {
+    chai.expect(getAppModules(app)).to.equal('/foo/node_modules/')
+  })
+})
+
+describe('getModulePath', () => {
+  it('creates path to module file or dir', () => {
+    const filepath = getModulePath('README.md', 'signalk-webapp')(app)
+    chai.expect(filepath).to.equal('/foo/node_modules/signalk-webapp/README.md')
+    chai
+      .expect(getModulePath('README.md', 'signalk-webapp', app))
+      .to.equal('/foo/node_modules/signalk-webapp/README.md')
+  })
+})
+describe('getModulePublic', () => {
+  it('creates path to module public dir', () => {
+    const filepath = getModulePublic('signalk-webapp')(app)
+    chai.expect(filepath).to.equal('/foo/node_modules/signalk-webapp/public')
+  })
+})

--- a/lib/config/get.test.js
+++ b/lib/config/get.test.js
@@ -3,7 +3,7 @@ const {
   getAppPath,
   getAppModulesPath,
   getModulePath,
-  getModulePublic
+  getModulePublicPath
 } = require('./get')
 
 const app = { config: { appPath: '/foo' } }
@@ -28,9 +28,9 @@ describe('getModulePath', () => {
       .to.equal('/foo/node_modules/signalk-webapp/README.md')
   })
 })
-describe('getModulePublic', () => {
+describe('getModulePublicPath', () => {
   it('creates path to module public dir', () => {
-    const filepath = getModulePublic('signalk-webapp')(app)
+    const filepath = getModulePublicPath('signalk-webapp')(app)
     chai.expect(filepath).to.equal('/foo/node_modules/signalk-webapp/public')
   })
 })

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -22,11 +22,11 @@ var _ = require('lodash')
 const modulesWithKeyword = require('../modules').modulesWithKeyword
 const getLogger = require('../logging').getLogger
 const _putPath = require('../put').putPath
-const { getModulePublic } = require('../config/get')
+const { getModulePublicPath } = require('../config/get')
 const { queryRequest } = require('../requestResponse')
 
 // #521 Returns path to load plugin-config assets.
-const getPluginConfigPublic = getModulePublic('@signalk/plugin-config')
+const getPluginConfigPublic = getModulePublicPath('@signalk/plugin-config')
 
 const DEFAULT_ENABLED_PLUGINS = process.env['DEFAULTENABLEDPLUGINS']
   ? process.env['DEFAULTENABLEDPLUGINS'].split(',')

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -21,7 +21,7 @@ const fetch = require('node-fetch')
 const path = require('path')
 const _ = require('lodash')
 const semver = require('semver')
-const { addModules } = require('./config/get')
+const { addModulesPath } = require('./config/get')
 
 function findModulesInDir (dir, keyword) {
   // If no directory by name return empty array.
@@ -67,7 +67,7 @@ function findModulesInDir (dir, keyword) {
 // Extract unique directory paths from app object.
 function getModulePaths ({ config: { appPath, configPath } }) {
   // appPath is the app working directory.
-  return _.uniq([configPath, appPath]).map(addModules)
+  return _.uniq([configPath, appPath]).map(addModulesPath)
 }
 
 const getModuleSortName = x => (x.module || '').replace('@signalk', ' ')

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -79,8 +79,13 @@ const priorityPrefix = (a, b) =>
 // Searches for installed modules that contain `keyword`.
 function modulesWithKeyword (app, keyword) {
   // _.flatten since values are inside an array. [[modules...], [modules...]]
-  return _.flatten(
-    getModulePaths(app).map(pathOption => findModulesInDir(pathOption, keyword))
+  return _.uniqBy(
+    _.flatten(
+      getModulePaths(app).map(pathOption =>
+        findModulesInDir(pathOption, keyword)
+      )
+    ),
+    'module'
   ).sort(priorityPrefix)
 }
 

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -67,7 +67,7 @@ function findModulesInDir (dir, keyword) {
 // Extract unique directory paths from app object.
 function getModulePaths ({ config: { appPath, configPath } }) {
   // appPath is the app working directory.
-  return _.uniq([appPath, configPath]).map(addModules)
+  return _.uniq([configPath, appPath]).map(addModules)
 }
 
 const getModuleSortName = x => (x.module || '').replace('@signalk', ' ')

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -19,7 +19,7 @@ const spawn = require('child_process').spawn
 const debug = require('debug')('signalk:modules')
 const fetch = require('node-fetch')
 const path = require('path')
-const _ = require('lodash')
+const _ = require('lodash/fp')
 const semver = require('semver')
 const { addModulesPath } = require('./config/get')
 
@@ -70,24 +70,16 @@ function getModulePaths ({ config: { appPath, configPath } }) {
   return _.uniq([configPath, appPath]).map(addModulesPath)
 }
 
-const getModuleSortName = x => (x.module || '').replace('@signalk', ' ')
+const sortModules = _.sortBy([_.startsWith('@signalk'), 'module'])
 
-// Sort handler that puts strings with '@signalk' first.
-const priorityPrefix = (a, b) =>
-  getModuleSortName(a).localeCompare(getModuleSortName(b))
-
-// Searches for installed modules that contain `keyword`.
-function modulesWithKeyword (app, keyword) {
-  // _.flatten since values are inside an array. [[modules...], [modules...]]
-  return _.uniqBy(
-    _.flatten(
-      getModulePaths(app).map(pathOption =>
-        findModulesInDir(pathOption, keyword)
-      )
-    ),
-    'module'
-  ).sort(priorityPrefix)
-}
+const modulesWithKeyword = (app, keyword) =>
+  _.flow(
+    getModulePaths,
+    _.map(_.partialRight(findModulesInDir, [keyword])),
+    _.flatten, // Since values are inside an array. [[modules...], [modules...]]
+    _.uniqBy('module'),
+    sortModules
+  )(app)
 
 function installModule (app, name, version, onData, onErr, onClose) {
   debug('installing: ' + name + ' ' + version)

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -21,6 +21,7 @@ const fetch = require('node-fetch')
 const path = require('path')
 const _ = require('lodash')
 const semver = require('semver')
+const { addModules } = require('./config/get')
 
 function findModulesInDir (dir, keyword) {
   // If no directory by name return empty array.
@@ -64,12 +65,9 @@ function findModulesInDir (dir, keyword) {
 }
 
 // Extract unique directory paths from app object.
-function getModulePaths (app) {
+function getModulePaths ({ config: { appPath, configPath } }) {
   // appPath is the app working directory.
-  const { appPath, configPath } = app.config
-  return (appPath === configPath ? [appPath] : [appPath, configPath]).map(
-    pathOption => path.join(pathOption, 'node_modules/')
-  )
+  return _.uniq([appPath, configPath]).map(addModules)
 }
 
 const getModuleSortName = x => (x.module || '').replace('@signalk', ' ')

--- a/lib/serverroutes.js
+++ b/lib/serverroutes.js
@@ -15,17 +15,17 @@
 */
 
 const fs = require('fs')
-const page = require('./page')
 const debug = require('debug')('signalk-server:serverroutes')
 const path = require('path')
 const _ = require('lodash')
+const express = require('express')
+const serialBingings = require('@serialport/bindings')
+const { getAISShipTypeName } = require('@signalk/signalk-schema')
+const page = require('./page')
 const config = require('./config/config')
 const { getHttpPort, getSslPort } = require('./ports')
-const express = require('express')
-const { getAISShipTypeName } = require('@signalk/signalk-schema')
 const { queryRequest } = require('./requestResponse')
-const serialBingings = require('@serialport/bindings')
-
+const { getModulePublic } = require('./config/get')
 const defaultSecurityStrategy = './tokensecurity'
 const skPrefix = '/signalk/v1'
 
@@ -34,9 +34,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
 
   app.use(
     '/admin',
-    express.static(
-      __dirname + '/../node_modules/@signalk/server-admin-ui/public'
-    )
+    express.static(getModulePublic('@signalk/server-admin-ui', app))
   )
 
   app.get('/', (req, res) => {

--- a/lib/serverroutes.js
+++ b/lib/serverroutes.js
@@ -25,7 +25,7 @@ const page = require('./page')
 const config = require('./config/config')
 const { getHttpPort, getSslPort } = require('./ports')
 const { queryRequest } = require('./requestResponse')
-const { getModulePublic } = require('./config/get')
+const { getModulePublicPath } = require('./config/get')
 const defaultSecurityStrategy = './tokensecurity'
 const skPrefix = '/signalk/v1'
 
@@ -34,7 +34,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
 
   app.use(
     '/admin',
-    express.static(getModulePublic('@signalk/server-admin-ui', app))
+    express.static(getModulePublicPath('@signalk/server-admin-ui', app))
   )
 
   app.get('/', (req, res) => {

--- a/lib/serverroutes.js
+++ b/lib/serverroutes.js
@@ -19,7 +19,7 @@ const debug = require('debug')('signalk-server:serverroutes')
 const path = require('path')
 const _ = require('lodash')
 const express = require('express')
-const serialBingings = require('@serialport/bindings')
+const serialBindings = require('@serialport/bindings')
 const { getAISShipTypeName } = require('@signalk/signalk-schema')
 const page = require('./page')
 const config = require('./config/config')
@@ -517,7 +517,7 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
   })
 
   app.get('/serialports', (req, res, next) => {
-    serialBingings
+    serialBindings
       .list()
       .then(ports => {
         res.json(ports.map(port => port.comName))


### PR DESCRIPTION
To resolve #555 it is important to allow the constructor to pass in a value for `config.appPath` and for the code to respect that path instead of trying `../../`. 

This PR changes checkPackageVersion() to use `config.appPath` by utilizing the helper function `getAppModuleInfo()`.

I also cleaned up `getModulePaths()` to utilize helper function `addModules()`.