### PR TITLE
fix: configPath should have priority over appPath

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -21,6 +21,7 @@ const fetch = require('node-fetch')
 const path = require('path')
 const _ = require('lodash')
 const semver = require('semver')
+const { addModules } = require('./config/get')
 
 function findModulesInDir (dir, keyword) {
   // If no directory by name return empty array.
@@ -64,12 +65,9 @@ function findModulesInDir (dir, keyword) {
 }
 
 // Extract unique directory paths from app object.
-function getModulePaths (app) {
+function getModulePaths ({ config: { appPath, configPath } }) {
   // appPath is the app working directory.
-  const { appPath, configPath } = app.config
-  return (appPath === configPath ? [appPath] : [appPath, configPath]).map(
-    pathOption => path.join(pathOption, 'node_modules/')
-  )
+  return _.uniq([configPath, appPath]).map(addModules)
 }
 
 const getModuleSortName = x => (x.module || '').replace('@signalk', ' ')

--- a/lib/modules.test.js
+++ b/lib/modules.test.js
@@ -21,3 +21,5 @@ describe('modulesWithKeyword', () => {
     chai.expect(_.map(moduleList, 'module')).to.eql(expectedModules)
   })
 })
+
+// @TODO Need a test to confirm configPath has priority over appPath in `getModulePaths()`.


### PR DESCRIPTION
> The ones in the config directory should be preferred, otherwise installing an update from the app store will not work. Originally in https://github.com/SignalK/signalk-server-node/pull/445

Updated getModulePaths() to search configPath first.