### PR TITLE
fix: plugin/webapp load logic

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -61,5 +61,6 @@ letsencrypt
 docker
 
 test
+lib/**/*.test.js*
 
 packages

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -67,7 +67,7 @@ function findModulesInDir (dir, keyword) {
 function getModulePaths (app) {
   // appPath is the app working directory.
   const { appPath, configPath } = app.config
-  return (appPath === configPath ? [appPath] : [appPath, configPath]).map(
+  return (appPath === configPath ? [appPath] : [configPath, appPath]).map(
     pathOption => path.join(pathOption, 'node_modules/')
   )
 }
@@ -80,9 +80,14 @@ const priorityPrefix = (a, b) =>
 
 // Searches for installed modules that contain `keyword`.
 function modulesWithKeyword (app, keyword) {
-  // _.flatten since values are inside an array. [[modules...], [modules...]]
-  return _.flatten(
-    getModulePaths(app).map(pathOption => findModulesInDir(pathOption, keyword))
+  return _.uniqBy(
+    // _.flatten since values are inside an array. [[modules...], [modules...]]
+    _.flatten(
+      getModulePaths(app).map(pathOption =>
+        findModulesInDir(pathOption, keyword)
+      )
+    ),
+    moduleData => moduleData.module
   ).sort(priorityPrefix)
 }
 

--- a/lib/modules.test.js
+++ b/lib/modules.test.js
@@ -1,10 +1,8 @@
 const chai = require('chai')
 const _ = require('lodash')
+const fs = require('fs')
+const path = require('path')
 const { modulesWithKeyword } = require('./modules')
-const { load } = require('./config/config')
-
-const app = { get: () => {} }
-load(app)
 
 const expectedModules = [
   '@signalk/freeboard-sk',
@@ -15,9 +13,43 @@ const expectedModules = [
   '@signalk/simplegauges'
 ]
 
+const testTempDir = path.join(
+  require('os').tmpdir(),
+  '_skservertest_modules' + Date.now()
+)
+
+const app = {
+  config: {
+    appPath: path.join(__dirname + '/../'),
+    configPath: testTempDir
+  }
+}
+
+fs.mkdirSync(testTempDir)
+const tempNode_modules = path.join(testTempDir, 'node_modules/')
+fs.mkdirSync(path.join(testTempDir, 'node_modules'))
+fs.mkdirSync(path.join(testTempDir, 'node_modules/@signalk'))
+let configMaptrackerDirectory = path.join(
+  testTempDir,
+  'node_modules/@signalk/maptracker'
+)
+fs.mkdirSync(configMaptrackerDirectory)
+
+const maptrackerPkg = require(path.join(
+  app.config.appPath,
+  'node_modules/@signalk/maptracker/package.json'
+))
+maptrackerPkg.version = '1000.0.0'
+fs.writeFileSync(
+  path.join(configMaptrackerDirectory, 'package.json'),
+  JSON.stringify(maptrackerPkg)
+)
+
 describe('modulesWithKeyword', () => {
   it('returns a list of modules', () => {
     const moduleList = modulesWithKeyword(app, 'signalk-webapp')
     chai.expect(_.map(moduleList, 'module')).to.eql(expectedModules)
+    chai.expect(moduleList[0].location).to.not.eql(tempNode_modules)
+    chai.expect(moduleList[2].location).to.eql(tempNode_modules)
   })
 })

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "changelog": "github-changes -o signalk -r signalk-server-node -a --only-pulls --use-commit-body --data=pulls  --tag-name=v$npm_package_version",
     "release": "git tag -d v$npm_package_version ; npm run changelog && git add CHANGELOG.md && git commit -m 'chore: update changelog' && git tag v$npm_package_version && git push --tags && git push && git tag -d latest && git push origin :refs/tags/latest && git tag latest && git push origin tag latest",
     "start": "node bin/signalk-server",
-    "test": "mocha --exit",
-    "test-lib": "mocha $(find lib -name '*test.js')",
+    "test": "mocha --exit ./test/**/*.js ./lib/**/*.test.js",
     "format": "prettier-standard lib/**/*.js* providers/*.js* test/*.js* index.js",
     "heroku-postbuild": "npm install @signalk/simple-gpx"
   },


### PR DESCRIPTION
Revert plugin/webapp load ordering to how it has been:
prefer modules in config directory and ignore duplicates
if they exist in server's node_modules.

Add test for the preference order.

Bring lib/modules.test.js to the fold: include it in `npm test`, that Travis uses, and npmignore all lib/**/\*.test.js\* files.