### PR TITLE
feature: server as include (checkPackageVersion, test)

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -35,6 +35,9 @@ function load (app) {
   config.getExternalHostname = getExternalHostname.bind(config, config)
   config.getExternalPort = getExternalPort.bind(config, config)
 
+  config.appPath = config.appPath || path.normalize(__dirname + '/../../')
+  debug('appPath:' + config.appPath)
+
   try {
     const pkg = require('../../package.json')
     config.name = pkg.name
@@ -43,14 +46,12 @@ function load (app) {
     config.version = pkg.version
     config.description = pkg.description
 
-    checkPackageVersion('@signalk/server-admin-ui', pkg)
+    checkPackageVersion('@signalk/server-admin-ui', pkg, app.config.appPath)
   } catch (err) {
     console.error('error parsing package.json', err)
     process.exit(1)
   }
 
-  config.appPath = config.appPath || path.normalize(__dirname + '/../../')
-  debug('appPath:' + config.appPath)
   setConfigDirectory(app)
   if (_.isObject(app.config.settings)) {
     debug('Using settings from constructor call, not reading defaults')
@@ -118,9 +119,14 @@ function load (app) {
   require('./production')(app)
 }
 
-function checkPackageVersion (name, pkg) {
+function checkPackageVersion (name, pkg, appPath) {
   const expected = pkg.dependencies[name]
-  const installed = require(`../../node_modules/${name}/package.json`)
+  const installed = require(path.join(
+    appPath,
+    'node_modules',
+    name,
+    'package.json'
+  ))
 
   if (!semver.satisfies(installed.version, expected)) {
     console.error(

--- a/test-server-as-include/package.json
+++ b/test-server-as-include/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "empty",
+  "version": "1.0.0",
+  "main": "works-as-include.js",
+  "dependencies": {
+    "app-root-path": "^2.1.0"
+  }
+}

--- a/test-server-as-include/run.sh
+++ b/test-server-as-include/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+TMPDIR=$(mktemp -d)
+
+trap "exit 1"         HUP INT PIPE QUIT TERM
+trap "rm -rf $TMPDIR" EXIT
+
+BASEDIR=$(dirname $0)
+
+#copy test files to the tmp directory
+cp -r ${BASEDIR} $TMPDIR
+
+#pack the server and install from the packed tar file
+ORIGINDIR=$(PWD)
+PACKEDTARFILE=$(npm pack 2>/dev/null)
+cd $TMPDIR/$BASEDIR
+npm install
+npm install $ORIGINDIR/$PACKEDTARFILE
+
+export SETTINGSDIR=$TMPDIR/settings
+mkdir $SETTINGSDIR
+
+node works-as-include.js
+

--- a/test-server-as-include/works-as-include.js
+++ b/test-server-as-include/works-as-include.js
@@ -1,0 +1,12 @@
+const appRoot = require('app-root-path')
+const SignalKServer = require('signalk-server')
+const path = require('path')
+
+const config = {
+  appPath: appRoot.path,
+  configPath: process.env.SETTINGSDIR
+}
+
+console.log(config)
+const server = new SignalKServer({ config });
+server.start()


### PR DESCRIPTION
Change checkPackageVersion so that the server can be run as an included module.

Add a separate test for starting the server embedded within another Node application.

Fixes #555.