### PR TITLE
fix: -s settings configpath

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -141,6 +141,7 @@ function getConfigDirectory ({ argv, config, env }) {
     env.SIGNALK_NODE_CONFIG_DIR,
     config.configPath,
     argv.c,
+    argv.s && config.appPath,
     env.HOME && path.join(env.HOME, '.signalk'),
     config.appPath
   ]

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -1,6 +1,8 @@
 const { expect } = require('chai')
 const { getConfigDirectory } = require('./config')
 const { appPath } = require('./get')
+const path = require('path')
+const fs = require('fs')
 
 const app = {
   argv: {},
@@ -35,5 +37,15 @@ describe('getConfigDirectory', () => {
     delete theApp.config.configPath
     delete theApp.env.HOME
     expect(getConfigDirectory(theApp)).to.equal('/var/node/signalk')
+  })
+  it('-s overrides configPath with appPath', () => {
+    const theApp = JSON.parse(JSON.stringify(app))
+    delete theApp.env.SIGNALK_NODE_CONFIG_DIR
+    delete theApp.config.configPath
+    theApp.argv.s = path.join(
+      __dirname,
+      '../../settings/n2k-from-file-settings.json'
+    )
+    expect(getConfigDirectory(theApp)).to.equal(theApp.config.appPath)
   })
 })

--- a/lib/config/config.test.js
+++ b/lib/config/config.test.js
@@ -19,16 +19,21 @@ describe('getConfigDirectory', () => {
     expect(getConfigDirectory(app)).to.equal('/data/signalk/config')
   })
   it('Constructor configPath has priority when no env SK Config Dir.', () => {
-    delete app.env.SIGNALK_NODE_CONFIG_DIR
-    expect(getConfigDirectory(app)).to.equal('/data/signalk-config')
+    const theApp = JSON.parse(JSON.stringify(app))
+    delete theApp.env.SIGNALK_NODE_CONFIG_DIR
+    expect(getConfigDirectory(theApp)).to.equal('/data/signalk-config')
   })
   it('No config setting then defaults to user dir.', () => {
-    delete app.config.configPath
-    expect(getConfigDirectory(app)).to.equal('/user/foo/.signalk')
+    const theApp = JSON.parse(JSON.stringify(app))
+    delete theApp.env.SIGNALK_NODE_CONFIG_DIR
+    delete theApp.config.configPath
+    expect(getConfigDirectory(theApp)).to.equal('/user/foo/.signalk')
   })
   it('Use the node process dir `appPath` as last resort.', () => {
-    delete app.config.configPath
-    delete app.env.HOME
-    expect(getConfigDirectory(app)).to.equal('/var/node/signalk')
+    const theApp = JSON.parse(JSON.stringify(app))
+    delete theApp.env.SIGNALK_NODE_CONFIG_DIR
+    delete theApp.config.configPath
+    delete theApp.env.HOME
+    expect(getConfigDirectory(theApp)).to.equal('/var/node/signalk')
   })
 })


### PR DESCRIPTION
Go back to how things have been working: if settings are specified with -s command line option (like bin/n2k-from-file and bin/nmea-from-file) configPath defaults to appPath, which is set to the app directory.