### PR TITLE
feature: add MAXSENDBUFFERSIZE guard against slow/dysfunctional clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Environment variables
 - `DEFAULTENABLEDPLUGINS` a comma separated list of plugin ids that are overridden to be enabled by default if no setttings exist. lower preference than `DISABLEPLUGINS`
 - `SECURITYSTRATEGY` override the security strategy module name
 - `WSCOMPRESSION` compress websocket messages
+- `MAXSENDBUFFERSIZE` the maximum number of bytes allowed in the server's send buffer of a WebSocket connection. The connection will be terminated if this is exceeded. Guards against slow or dysfunctional clients that can not cope with the message volume. Default is 512 * 1024 bytes.
 
 
 Real Inputs

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -146,6 +146,8 @@ module.exports = function (app) {
       }
     ]
 
+    const assertBufferSize = getAssertBufferSize(app.config)
+
     primuses = allWsOptions.map(primusOptions => {
       const primus = new Primus(app.server, primusOptions)
 
@@ -169,6 +171,7 @@ module.exports = function (app) {
           )
           if (filtered) {
             spark.write(filtered)
+            assertBufferSize(spark)
           }
         }
 
@@ -191,7 +194,7 @@ module.exports = function (app) {
             }
 
             if (msg.subscribe) {
-              processSubscribe(app, unsubscribes, spark, msg)
+              processSubscribe(app, unsubscribes, spark, assertBufferSize, msg)
             }
 
             if (msg.unsubscribe) {
@@ -468,7 +471,7 @@ function processUpdates (app, pathSources, spark, msg) {
   })
 }
 
-function processSubscribe (app, unsubscribes, spark, msg) {
+function processSubscribe (app, unsubscribes, spark, assertBufferSize, msg) {
   app.subscriptionmanager.subscribe(
     msg,
     unsubscribes,
@@ -477,6 +480,7 @@ function processSubscribe (app, unsubscribes, spark, msg) {
       var filtered = app.securityStrategy.filterReadDelta(spark.request, msg)
       if (filtered) {
         spark.write(filtered)
+        assertBufferSize(spark)
       }
     },
     spark.request.skPrincipal
@@ -600,5 +604,25 @@ function startServerEvents (app, spark) {
       type: 'RECEIVE_LOGIN_STATUS',
       data: app.securityStrategy.getLoginStatus(spark.request)
     })
+  }
+}
+
+function getAssertBufferSize (config) {
+  const MAXSENDBUFFERSIZE =
+    process.env.MAXSENDBUFFERSIZE || config.maxSendBufferSize || 512 * 1024
+  debug(`MAXSENDBUFFERSIZE:${MAXSENDBUFFERSIZE}`)
+
+  if (MAXSENDBUFFERSIZE === 0) {
+    return () => {}
+  }
+
+  return spark => {
+    debug(spark.id + ' ' + spark.request.socket.bufferSize)
+    if (spark.request.socket.bufferSize > MAXSENDBUFFERSIZE) {
+      spark.end({
+        errorMessage: 'Server outgoing buffer overflow, terminating connection'
+      })
+      console.error('Send buffer overflow, terminating connection ' + spark.id)
+    }
   }
 }


### PR DESCRIPTION
Add check against WebSocket send buffers growing limitlessly
if a client can or will not read the data fast enough or at all.