### PR TITLE
fix: /plugins/<id> enabled with signalk-plugin-enabled-by-default

### DIFF
--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -332,7 +332,7 @@ module.exports = function (app) {
       })
     }
 
-    const options = getPluginOptions(plugin.id)
+    const startupOptions = getPluginOptions(plugin.id)
     const restart = newConfiguration => {
       const pluginOptions = getPluginOptions(plugin.id)
       pluginOptions.configuration = newConfiguration
@@ -346,19 +346,22 @@ module.exports = function (app) {
       })
     }
 
-    if (
-      _.isUndefined(options.enabled) &&
-      metadata['signalk-plugin-enabled-by-default']
-    ) {
-      options.enabled = true
-      options.configuration = {}
+    if (isEnabledByPackageEnableDefault(startupOptions, metadata)) {
+      startupOptions.enabled = true
+      startupOptions.configuration = {}
       plugin.enabledByDefault = true
     }
 
-    if (options && options.enabled) {
-      doPluginStart(app, plugin, location, options.configuration, restart)
+    if (startupOptions && startupOptions.enabled) {
+      doPluginStart(
+        app,
+        plugin,
+        location,
+        startupOptions.configuration,
+        restart
+      )
     }
-    plugin.enableLogging = options.enableLogging
+    plugin.enableLogging = startupOptions.enableLogging
     app.plugins.push(plugin)
     app.pluginsMap[plugin.id] = plugin
 
@@ -368,9 +371,14 @@ module.exports = function (app) {
 
     var router = express.Router()
     router.get('/', (req, res) => {
-      const options = getPluginOptions(plugin.id)
+      const currentOptions = getPluginOptions(plugin.id)
+      const enabledByDefault = isEnabledByPackageEnableDefault(
+        currentOptions,
+        metadata
+      )
       res.json({
-        enabled: options.enabled,
+        enabled: enabledByDefault || currentOptions.enabled,
+        enabledByDefault,
         id: plugin.id,
         name: plugin.name,
         version: plugin.version
@@ -409,3 +417,7 @@ module.exports = function (app) {
     }
   }
 }
+
+const isEnabledByPackageEnableDefault = (options, metadata) =>
+  _.isUndefined(options.enabled) &&
+  metadata['signalk-plugin-enabled-by-default']


### PR DESCRIPTION
The response was missing 'enabled' property if the plugin
was enabled by signalk-plugin-enabled-by-default in package.json.

Add enabledByDefault to the response

Rename the different options variables to avoid confusion.