### PR TITLE
fix: keep working with data logging errors

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const FileTimestampStream = require('file-timestamp-stream')
+const { FileTimestampStream } = require('file-timestamp-stream')
 const path = require('path')
 const debug = require('debug')('signalk:logging')
 const fs = require('fs')
@@ -41,6 +41,9 @@ function getLogger (app, discriminator = '', logdir) {
     })
   }
   var logger = loggers[fullLogdir]
+  logger.on('error', err => {
+    console.error(`Error opening data logging file: ${err.message}`)
+  })
 
   return msg => {
     try {

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "express": "^4.10.4",
     "express-namespace": "^0.1.1",
     "figlet": "^1.2.0",
-    "file-timestamp-stream": "0.6.0",
+    "file-timestamp-stream": "^2.1.2",
     "flatmap": "0.0.3",
     "geolib": "^2.0.24",
     "get-installed-path": "^4.0.8",


### PR DESCRIPTION
Not being able to open/rotate/write in the data logging
file would crash the server. This adds error handling and
logging errors to stderr.