### PR TITLE
fix: handle delta paths with the word path

### DIFF
--- a/lib/deltacache.js
+++ b/lib/deltacache.js
@@ -160,7 +160,7 @@ DeltaCache.prototype.getCachedDeltas = function (user, contextFilter, key) {
 }
 
 function pickDeltasFromBranch (acc, obj) {
-  if (isUndefined(obj.path)) {
+  if (isUndefined(obj.path) || isUndefined(obj.value)) {
     // not a delta, so process possible children
     _.values(obj).reduce(pickDeltasFromBranch, acc)
   } else {

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -1,4 +1,4 @@
-var chai = require('chai')
+const chai = require('chai')
 chai.Should()
 chai.use(require('chai-things'))
 chai.use(require('@signalk/signalk-schema').chaiModule)
@@ -25,7 +25,7 @@ const testDelta = {
       timestamp: '2014-05-03T09:14:11.099Z',
       values: [
         {
-          path: 'navigation.log',
+          path: 'imaginary.path',
           value: 17404540
         }
       ]
@@ -64,12 +64,12 @@ const expectedOrder = [
   '',
   'navigation.speedOverGround',
   'navigation.courseOverGroundTrue',
-  'navigation.log',
+  'imaginary.path',
   'navigation.trip.log'
 ]
 
 describe('deltacache', () => {
-  var serverP, port, deltaUrl, deltaP
+  let serverP, port, deltaUrl, deltaP
 
   function sendDelta (delta) {
     return rp({ url: deltaUrl, method: 'POST', json: delta })
@@ -95,12 +95,11 @@ describe('deltacache', () => {
   it('returns valid full tree', function () {
     return serverP.then(server => {
       return deltaP.then(() => {
-        var fullTree = server.app.deltaCache.buildFull(null, [])
-        fullTree.should.be.validSignalK
+        const fullTree = server.app.deltaCache.buildFull(null, [])
 
-        var self = _.get(fullTree, fullTree.self)
+        const self = _.get(fullTree, fullTree.self)
         self.should.have.nested.property('navigation.trip.log.value', 43374)
-        self.should.have.nested.property('navigation.log.value', 17404540)
+        self.should.have.nested.property('imaginary.path.value', 17404540)
         self.should.have.nested.property(
           'navigation.courseOverGroundTrue.value',
           172.9
@@ -110,6 +109,11 @@ describe('deltacache', () => {
           3.85
         )
         self.should.have.nested.property('name', 'TestBoat')
+
+        delete fullTree.vessels[
+          'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
+        ].imaginary
+        fullTree.should.be.validSignalK
       })
     })
   })
@@ -117,9 +121,9 @@ describe('deltacache', () => {
   it('deltas ordered properly', function () {
     return serverP.then(server => {
       return deltaP.then(() => {
-        var deltas = server.app.deltaCache.getCachedDeltas(null, delta => true)
+        const deltas = server.app.deltaCache.getCachedDeltas(null, delta => true)
         assert(deltas.length == expectedOrder.length)
-        for (var i = 0; i < expectedOrder.length; i++) {
+        for (let i = 0; i < expectedOrder.length; i++) {
           deltas[i].updates[0].values[0].path.should.equal(expectedOrder[i])
         }
       })
@@ -129,7 +133,10 @@ describe('deltacache', () => {
   it('returns /sources correctly', function () {
     return serverP.then(server => {
       return deltaP.then(() => {
-        var fullTree = server.app.deltaCache.buildFull(null, ['sources'])
+        const fullTree = server.app.deltaCache.buildFull(null, ['sources'])
+        delete fullTree.vessels[
+          'urn:mrn:signalk:uuid:c0d79334-4e25-4245-8892-54e8ccc8021d'
+        ].imaginary
         fullTree.should.be.validSignalK
         fullTree.sources.should.deep.equal({ deltaFromHttp: {} })
       })


### PR DESCRIPTION
A path with the word 'path' was not handled properly, as the deltacache
leaf detection was triggered on the object at hand having a property
named 'path'.