### PR TITLE
fix: WebSocket related errors

### DIFF
--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -485,7 +485,7 @@ function processSubscribe (app, unsubscribes, spark, assertBufferSize, msg) {
   app.subscriptionmanager.subscribe(
     msg,
     unsubscribes,
-    spark.write,
+    spark.write.bind(spark),
     msg => {
       const filtered = app.securityStrategy.filterReadDelta(spark.request, msg)
       if (filtered) {

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -198,7 +198,7 @@ module.exports = function (app) {
             }
 
             if (msg.unsubscribe) {
-              processUnsubscribe(app, unsubscribes, msg)
+              processUnsubscribe(app, unsubscribes, msg, onChange)
             }
 
             if (msg.accessRequest) {
@@ -487,7 +487,7 @@ function processSubscribe (app, unsubscribes, spark, assertBufferSize, msg) {
   )
 }
 
-function processUnsubscribe (app, unsubscribes, msg) {
+function processUnsubscribe (app, unsubscribes, msg, onChange) {
   if (
     msg.unsubscribe &&
     msg.context === '*' &&

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -185,32 +185,42 @@ module.exports = function (app) {
         } else {
           spark.on('data', function (msg) {
             debug('<' + JSON.stringify(msg))
-            if (msg.token) {
-              spark.request.token = msg.token
-            }
+            try {
+              if (msg.token) {
+                spark.request.token = msg.token
+              }
 
-            if (msg.updates) {
-              processUpdates(app, pathSources, spark, msg)
-            }
+              if (msg.updates) {
+                processUpdates(app, pathSources, spark, msg)
+              }
 
-            if (msg.subscribe) {
-              processSubscribe(app, unsubscribes, spark, assertBufferSize, msg)
-            }
+              if (msg.subscribe) {
+                processSubscribe(
+                  app,
+                  unsubscribes,
+                  spark,
+                  assertBufferSize,
+                  msg
+                )
+              }
 
-            if (msg.unsubscribe) {
-              processUnsubscribe(app, unsubscribes, msg, onChange)
-            }
+              if (msg.unsubscribe) {
+                processUnsubscribe(app, unsubscribes, msg, onChange)
+              }
 
-            if (msg.accessRequest) {
-              processAccessRequest(spark, msg)
-            }
+              if (msg.accessRequest) {
+                processAccessRequest(spark, msg)
+              }
 
-            if (msg.login && app.securityStrategy.supportsLogin()) {
-              processLoginRequest(spark, msg)
-            }
+              if (msg.login && app.securityStrategy.supportsLogin()) {
+                processLoginRequest(spark, msg)
+              }
 
-            if (msg.put) {
-              processPutRequest(spark, msg)
+              if (msg.put) {
+                processPutRequest(spark, msg)
+              }
+            } catch (ex) {
+              console.error(ex)
             }
           })
         }

--- a/lib/interfaces/ws.js
+++ b/lib/interfaces/ws.js
@@ -185,6 +185,7 @@ module.exports = function (app) {
         } else {
           spark.on('data', function (msg) {
             debug('<' + JSON.stringify(msg))
+
             try {
               if (msg.token) {
                 spark.request.token = msg.token
@@ -219,8 +220,8 @@ module.exports = function (app) {
               if (msg.put) {
                 processPutRequest(spark, msg)
               }
-            } catch (ex) {
-              console.error(ex)
+            } catch (e) {
+              console.error(e)
             }
           })
         }

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -130,7 +130,7 @@ function getFarPosistionDelta () {
 }
 
 describe('Subscriptions', _ => {
-  var serverP, port, deltaUrl
+  let serverP, port, deltaUrl
 
   before(() => {
     serverP = freeport().then(p => {
@@ -151,7 +151,7 @@ describe('Subscriptions', _ => {
   }
 
   it('?subscribe=self subscription serves self data', function () {
-    var self, wsPromiser
+    let self, wsPromiser
 
     return serverP
       .then(_ => {
@@ -191,7 +191,7 @@ describe('Subscriptions', _ => {
   })
 
   it('default subscription serves self data', function () {
-    var self, wsPromiser
+    let self, wsPromiser
 
     return serverP
       .then(_ => {
@@ -226,7 +226,7 @@ describe('Subscriptions', _ => {
   })
 
   it('?subscribe=all subscription serves all data', function () {
-    var self, wsPromiser
+    let self, wsPromiser
 
     return serverP
       .then(_ => {
@@ -264,7 +264,7 @@ describe('Subscriptions', _ => {
   })
 
   it('?subscribe=none subscription serves no data', function () {
-    var self, wsPromiser
+    let self, wsPromiser
 
     return serverP
       .then(_ => {
@@ -298,19 +298,22 @@ describe('Subscriptions', _ => {
       })
   })
 
-  it('navigation.logTrip subscription serves correct data', function () {
-    var self, wsPromiser
+  it('unsubscribe all plus navigation.logTrip subscription serves correct data', function () {
+    let self, wsPromiser
 
     return serverP
       .then(_ => {
         wsPromiser = new WsPromiser(
-          'ws://localhost:' + port + '/signalk/v1/stream?subsribe=none'
+          'ws://localhost:' + port + '/signalk/v1/stream'
         )
         return wsPromiser.nextMsg()
       })
       .then(wsHello => {
         self = JSON.parse(wsHello).self
 
+        return wsPromiser.send({ context: '*', unsubscribe: [{ path: '*' }] })
+      })
+      .then(() => {
         return wsPromiser.send({
           context: 'vessels.*',
           subscribe: [
@@ -359,7 +362,7 @@ describe('Subscriptions', _ => {
   })
 
   it('name subscription serves correct data', function () {
-    var self, wsPromiser
+    let self, wsPromiser
 
     return serverP
       .then(_ => {
@@ -425,7 +428,7 @@ describe('Subscriptions', _ => {
   })
 
   it('relativePosition subscription serves correct data', function () {
-    var self, wsPromiser
+    let self, wsPromiser
 
     return serverP
       .then(_ => {


### PR DESCRIPTION
- fixes #712:  ws upstream messages like `{ "context": "*","unsubscribe": [ {"path": "*"} ]}` killing the server because of an undefined parameter
- fix subscription error handling (inconsistent subscriptions crashing the server)
- improve ws upstream error handling so that errors in handling messages do not crash the server