### PR TITLE
fix: nmea 0183 udp data with multiple lines per datagram fails

### DIFF
--- a/providers/simple.js
+++ b/providers/simple.js
@@ -9,6 +9,7 @@ const nmea0183_signalk = require('./nmea0183-signalk')
 const N2kToSignalK = require('./n2k-signalk')
 const Log = require('./log')
 const Liner = require('./liner')
+const SplittingLiner = require('./splitting-liner')
 const execute = require('./execute')
 const Udp = require('./udp')
 const Tcp = require('./tcp')
@@ -216,7 +217,7 @@ function nmea0183input (subOptions) {
   } else if (subOptions.type === 'tcpserver') {
     return [new TcpServer(subOptions), new Liner(subOptions)]
   } else if (subOptions.type === 'udp') {
-    return [new Udp(subOptions)]
+    return [new Udp(subOptions), new SplittingLiner(subOptions)]
   } else if (subOptions.type === 'serial') {
     const serialport = require('./serialport')
     return [new serialport(subOptions)]

--- a/providers/splitting-liner.js
+++ b/providers/splitting-liner.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Scott Bender <scott@scottbender.net>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Usage:
+ *  This is part of a PipedProvider that splits the input into separate lines and passes one line at a time to the next provider.
+ *  You can specify the line separator with the option lineSeparator.
+
+ {
+   "type": "providers/splitting-liner"
+ },
+
+ */
+
+const Transform = require('stream').Transform
+
+require('util').inherits(SplittingLiner, Transform)
+
+function SplittingLiner (options) {
+  Transform.call(this, {
+    objectMode: true
+  })
+  this.doPush = this.push.bind(this)
+  this.lineSeparator = options.lineSeparator || '\n'
+}
+
+SplittingLiner.prototype._transform = function (chunk, encoding, done) {
+  const data = chunk.toString()
+  const lines = data.split(this.lineSeparator)
+  lines.forEach(this.doPush)
+  done()
+}
+
+module.exports = SplittingLiner


### PR DESCRIPTION
When an 0183 udp datagram comes in with multiple messages, it fails because it never gets split into multiple lines and then the 0183 parser fails.