### PR TITLE
fix: exclude deprecated modules

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -139,7 +139,9 @@ function installModule (app, name, version, onData, onErr, onClose) {
 function findModulesWithKeyword (keyword) {
   return new Promise((resolve, reject) => {
     Promise.all([
-      fetch('https://api.npms.io/v2/search?size=250&q=keywords:' + keyword),
+      fetch(
+        `https://api.npms.io/v2/search?size=250&q=keywords:${keyword}+not:deprecated`
+      ),
       fetch(
         'http://registry.npmjs.org/-/v1/search?size=250&text=keywords:' +
           keyword


### PR DESCRIPTION
npms.io requires a separate condition in the url to
filter out deprecated modules.