### PR TITLE
fix: PayloadTooLargeError: request entity too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Environment variables
 - `SSLPORT` override the port for https/wss service. If defined activates ssl as forced, default protocol.
 - `EXTERNALPORT` the port used in /signalk response and Bonjour advertisement. Has precedence over configuration file.
 - `EXTERNALHOST` the host used in /signalk response and Bonjour advertisement. Has precedence over configuration file.
+- `FILEUPLOADSIZELIMIT` override the file upload size limit (default is '10mb')
 - `NMEA0183PORT`  override the port for the NMEA 0183 over tcp service (default 10110)
 - `TCPSTREAMPORT` override the port for the Signal K Streaming (deltas) over TCP
 - `TCPSTREAMADDRESS` override the address the Signal K Stream (deltas) over TCP is listening on

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,10 +48,12 @@ const express = require('express'),
   compareVersions = require('compare-versions')
 
 function Server (opts) {
+  const FILEUPLOADSIZELIMIT = process.env.FILEUPLOADSIZELIMIT || '10mb'
+  const bodyParser = require('body-parser')
   const app = express()
   app.use(require('compression')())
   app.use(require('cors')())
-  app.use(require('body-parser').json())
+  app.use(bodyParser.json({limit:FILEUPLOADSIZELIMIT}))
 
   this.app = app
   app.started = false


### PR DESCRIPTION
Resolves issue #732

Bumps the file upload limit size to 10 mb