### PR TITLE
fix: find admin ui when embedded

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -121,12 +121,16 @@ function load (app) {
 
 function checkPackageVersion (name, pkg, appPath) {
   const expected = pkg.dependencies[name]
-  const installed = require(path.join(
+  let modulePackageJsonPath = path.join(
     appPath,
     'node_modules',
     name,
     'package.json'
-  ))
+  )
+  if (!fs.existsSync(modulePackageJsonPath)) {
+    modulePackageJsonPath = path.join(appPath, '..', name, 'package.json')
+  }
+  const installed = require(modulePackageJsonPath)
 
   if (!semver.satisfies(installed.version, expected)) {
     console.error(


### PR DESCRIPTION
If you install signalk-server as a dependency with
npm install --save signalk-server
the admin ui ends up installed rooted at the same
level as signalk-server and the server fails to start, unless
we look for the admin ui also there.

This fix is not complete, as the admin ui will not work
like this, but the server starts.