### PR TITLE
fix: autodetect piping

### DIFF
--- a/providers/autodetect.js
+++ b/providers/autodetect.js
@@ -62,7 +62,7 @@ function DeMultiplexer (options) {
 require('util').inherits(DeMultiplexer, Writable)
 
 DeMultiplexer.prototype.pipe = function (target) {
-  this.splitter.pipe(target)
+  return this.splitter.pipe(target)
 }
 DeMultiplexer.prototype.write = function (chunk, encoding, callback) {
   return this.toTimestamped.write(chunk, encoding, callback)
@@ -128,7 +128,7 @@ Splitter.prototype._transform = function (msg, encoding, _done) {
 Splitter.prototype.pipe = function (target) {
   this.fromN2KJson.pipe(target)
   this.fromNMEA0183.pipe(target)
-  Transform.prototype.pipe.call(this, target)
+  return Transform.prototype.pipe.call(this, target)
 }
 
 function ToTimestamped (deMultiplexer, options) {


### PR DESCRIPTION
...pipe(autodetect).pipe(smthing)
has been working, but one more level
...pipe(ad).pipe(smthing).pipe(else)
failed, because autodetect.pipe was not
returning anything.