### PR TITLE
feature: use timestamp from multiplexed log

### DIFF
--- a/packages/streams/autodetect.js
+++ b/packages/streams/autodetect.js
@@ -94,7 +94,7 @@ Splitter.prototype._transform = function (msg, encoding, _done) {
   try {
     switch (msg.discriminator) {
       case 'A': {
-        const result = this.fromActisenseSerial.write(msg.data, encoding)
+        const result = this.fromActisenseSerial.write(msg, encoding)
         if (!result) {
           this.fromActisenseSerial.once('drain', _done)
           done = () => {}

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/SignalK/signalk-server-node#readme",
   "dependencies": {
-    "@canboat/canboatjs": "^1.3.0",
+    "@canboat/canboatjs": "^1.4.0",
     "@signalk/client": "^0.2.0",
     "@signalk/n2k-signalk": "^1.2.1",
     "@signalk/nmea0183-signalk": "^3.0.0",


### PR DESCRIPTION
Override N2K timestamp with the value from the multiplexed log.

Depends on [a change in canboat](https://github.com/canboat/canboatjs/pull/48).