### PR TITLE
feature: add option to override sample file timestamps

### DIFF
--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -82,6 +82,9 @@ function load (app) {
       ],
       enabled: true
     })
+    if (app.argv['override-timestamps']) {
+      app.config.overrideTimestampWithNow = true
+    }
   }
 
   if (app.argv['sample-n2k-data']) {
@@ -104,6 +107,9 @@ function load (app) {
       ],
       enabled: true
     })
+    if (app.argv['override-timestamps']) {
+      app.config.overrideTimestampWithNow = true
+    }
   }
 
   if (env.SSLPORT) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ function Server (opts) {
   const app = express()
   app.use(require('compression')())
   app.use(require('cors')())
-  app.use(bodyParser.json({limit:FILEUPLOADSIZELIMIT}))
+  app.use(bodyParser.json({ limit: FILEUPLOADSIZELIMIT }))
 
   this.app = app
   app.started = false
@@ -163,7 +163,7 @@ function Server (opts) {
             update['$source'] = providerId
           }
         }
-        if (!update.timestamp) {
+        if (!update.timestamp || app.config.overrideTimestampWithNow) {
           update.timestamp = new Date().toISOString()
         }
       })


### PR DESCRIPTION
When the included sample files are used for demoing or testing one
often needs data timestamped now instead of the original
timestamps. Furthermore plaka.log being just raw nmea0183 data
does not contain timestamps, expect for GGA's that have time but
no date.