### PR TITLE
fix: access request error handling with no security

### DIFF
--- a/lib/security.js
+++ b/lib/security.js
@@ -70,7 +70,7 @@ function getSecurityConfig (app, forceRead = false) {
       return JSON.parse(optionsAsString)
     } catch (e) {
       console.error('Could not parse security config')
-      console.error(e)
+      console.error(e.message)
       return {}
     }
   }

--- a/lib/serverroutes.js
+++ b/lib/serverroutes.js
@@ -255,6 +255,13 @@ module.exports = function (app, saveSecurityConfig, getSecurityConfig) {
   app.post(`${skPrefix}/access/requests`, (req, res) => {
     const config = getSecurityConfig(app)
     const ip = req.headers['x-forwarded-for'] || req.connection.remoteAddress
+    if (!app.securityStrategy.requestAccess) {
+      res.status(404).json({
+        message:
+          'Access requests not available. Server security may not be enabled.'
+      })
+      return
+    }
     app.securityStrategy
       .requestAccess(config, { accessRequest: req.body }, ip)
       .then((reply, config) => {


### PR DESCRIPTION
Return 404 with a nice error message if security is not configured
but a client tries to request access.

Fixes #762.