### PR TITLE
feature: add relevant RPi groups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM $IMAGE_BASE:8
 #COPY requires one valid argument, second can be nonexistent
 COPY empty_file tmp/qemu-arm-stati[c] /usr/bin/
 
-RUN groupadd -r signalk && useradd --no-log-init -r -g signalk signalk
+RUN groupadd -r signalk -g 1001 && groupadd -r i2c -g 998 && groupadd -r spi -g 999 && useradd -u 999 --no-log-init -r -g signalk -G dialout,i2c,spi signalk
 WORKDIR /home/signalk
 RUN chown -R signalk /home/signalk
 USER signalk


### PR DESCRIPTION
Add signalk service user to dialout (serial devices), i2c and spi
groups so that the server can have access to these devices. The group
ids are from Raspbian Lite Jessie installation.