### PR TITLE
chore: pin geolib to 2.0.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "figlet": "^1.2.0",
     "file-timestamp-stream": "^2.1.2",
     "flatmap": "0.0.3",
-    "geolib": "^2.0.24",
+    "geolib": "2.0.24",
     "get-installed-path": "^4.0.8",
     "inquirer": "^6.1.0",
     "jsonwebtoken": "^8.1.1",


### PR DESCRIPTION
2.0.26 fails with

TypeError: geolib.isPointInCircle is not a function
    at checkPosition (/Users/tjk/git-workspace/signalk/server-node/lib/subscriptionmanager.js:223:19)

Version 3 is out, so if this needs further work I suggest we
consider upgrading to that. But maybe after it settles a little
while.