### PR TITLE
Updated Docker setup, k8s deployment and --securityenabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,15 @@ FROM $IMAGE_BASE:8
 #COPY requires one valid argument, second can be nonexistent
 COPY empty_file tmp/qemu-arm-stati[c] /usr/bin/
 
-RUN groupadd -r signalk -g 1001 && groupadd -r i2c -g 998 && groupadd -r spi -g 999 && useradd -u 999 --no-log-init -r -g signalk -G dialout,i2c,spi signalk
-WORKDIR /home/signalk
-RUN chown -R signalk /home/signalk
-USER signalk
+RUN groupadd -r i2c -g 998 && groupadd -r spi -g 999 && usermod -a -G dialout,i2c,spi node
 
-COPY package*.json ./
-RUN npm install --only=production
+USER node
+
+RUN mkdir -p /home/node/signalk
+WORKDIR /home/node/signalk
 
 COPY . .
-
+RUN npm install --only=production
+RUN mkdir -p /home/node/.signalk
 EXPOSE 3000
-ENTRYPOINT bin/signalk-server
+ENTRYPOINT /home/node/signalk/bin/signalk-server --securityenabled

--- a/kubernetes.md
+++ b/kubernetes.md
@@ -1,0 +1,66 @@
+# Running Signalk in Docker and kubernetes
+
+Signalk-server can run in Docker and kubernetes. The following steps provide a guide on how to build an up-to-date Docker image, run it locally on Docker and eventually deploy it to kubernetes.
+
+## Preparations
+Checkout the Signalk source:
+```bash
+$ git clone https://github.com/SignalK/signalk-server-node.git
+$ cd signalk-server-node
+```
+
+## Docker
+First we build a Docker image with the name "signalk":
+
+```bash
+$ docker build -t signalk .
+```
+
+Then we can run it:
+```bash
+$ docker run --publish 3100:3000 --name signalk signalk
+```
+
+This will start a container named `signalk` from the image `signalk` that is accessible on http://localhost:3000.
+
+The container runs with `--securityenabled`, which means you'll have to login. Signalk-server allows you to specify the admin user and a password when you first log in.
+
+## Kubernetes
+Once the Docker image has been made, it can be deployed to Kubernetes.
+
+For this we first tag the Docker image so we can upload it to a remote registy. E.g:
+
+```bash
+$ docker tag signalk gcr.io/wouterdebie-personal/signalk
+```
+
+The format for the tag is `<REGISTRY>/<PROJECT>/<APPLICATION>`
+
+After that we can push the image to the registry:
+```bash
+$ docker push gcr.io/wouterdebie-personal/signalk
+```
+
+Edit `kubernetes/signalk-deployment.yaml` and set the correct image that is supposed to be used.
+
+Once the image is pushed, we can deploy the application (this assumes kubernetes is properly setup):
+
+```bash
+$ kubectl create -f kubernetes/signalk-deployment.yaml
+```
+
+This deployment specification does a few things:
+- It creates a `PersistentVolumeClaim`, that is used to store the server configuration. A persistent volume is mounted at `~/.signalk`.
+- It creates a `Pod` and starts a container running the application.
+- It creates a `Service` that exposes the application on a public IP on port 80.
+
+To check the external IP of the application:
+```bash
+$ kubectl get service
+NAME         TYPE           CLUSTER-IP    EXTERNAL-IP    PORT(S)        AGE
+kubernetes   ClusterIP      10.12.0.1     <none>         443/TCP        27h
+signalk      LoadBalancer   10.12.12.44   <EXTERNAL_IP>  80:31381/TCP   26m
+```
+
+Test your setup by going to http://<EXTERNAL_IP>
+

--- a/kubernetes/signalk-deployment.yaml
+++ b/kubernetes/signalk-deployment.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: signalk
+  name: signalk
+  namespace: default
+spec:
+  externalTrafficPolicy: Cluster
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 3000
+  selector:
+    app: signalk
+  sessionAffinity: None
+  type: LoadBalancer
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: signalk
+  name: signalkpvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+  creationTimestamp: 2019-06-28T17:50:07Z
+  generation: 1
+  labels:
+    app: signalk
+  name: signalk
+  namespace: default
+  resourceVersion: "228897"
+  selfLink: /apis/extensions/v1beta1/namespaces/default/deployments/signalk
+  uid: 2aad4b9c-99cd-11e9-a760-42010a80002e
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: signalk
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: signalk
+    spec:
+      containers:
+      - image: gcr.io/wouterdebie-personal/signalk
+        imagePullPolicy: Always
+        name: signalk
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /home/node/.signalk
+          name: home-node-dotsignalk
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: home-node-dotsignalk
+        persistentVolumeClaim:
+          claimName: signalkpvc
+
+

--- a/lib/config/config.js
+++ b/lib/config/config.js
@@ -112,6 +112,10 @@ function load (app) {
     }
   }
 
+  if (app.argv['securityenabled'] && !app.config.security) {
+    app.config.settings.security = { strategy: './tokensecurity' }
+  }
+
   if (env.SSLPORT) {
     config.settings.ssl = true
   }


### PR DESCRIPTION
This commit updates the Docker configuration. It moves away
from running as a `signalk` user and sticks to the `node` user.

It also adds a kubernetes deployment definition and adds a parameter that
enables security by default.