### PR TITLE
refactor: use the in memory full tree for REST requests

### DIFF
--- a/lib/dummysecurity.js
+++ b/lib/dummysecurity.js
@@ -70,6 +70,10 @@ module.exports = function (app, config) {
 
     authorizeWS: req => {},
 
+    anyACLs: () => {
+      return false
+    },
+
     checkACL: (id, context, path, source, operation) => {
       return true
     },

--- a/lib/interfaces/rest.js
+++ b/lib/interfaces/rest.js
@@ -37,7 +37,6 @@ module.exports = function (app) {
 
       app.get(apiPathPrefix + '*', function (req, res, next) {
         let path = String(req.path).replace(apiPathPrefix, '')
-        const data = app.signalk.retrieve()
 
         if (path === 'self') {
           return res.json(`vessels.${app.selfId}`)
@@ -127,7 +126,12 @@ module.exports = function (app) {
             }
           }
         } else {
-          const last = app.deltaCache.buildFull(req.skPrincipal, path)
+          let last
+          if (app.securityStrategy.anyACLs()) {
+            last = app.deltaCache.buildFull(req.skPrincipal, path)
+          } else {
+            last = app.signalk.retrieve()
+          }
           sendResult(last, path)
         }
       })

--- a/lib/tokensecurity.js
+++ b/lib/tokensecurity.js
@@ -547,6 +547,11 @@ module.exports = function (app, config) {
     return false
   }
 
+  strategy.anyACLs = () => {
+    const configuration = getConfiguration()
+    return configuration.acls && configuration.acls.length
+  }
+
   strategy.filterReadDelta = (principal, delta) => {
     const configuration = getConfiguration()
     if (delta.updates && configuration.acls && configuration.acls.length) {


### PR DESCRIPTION
Building full from the delta cache is too slow when there's a lot of data. (takes 4 seconds on my boat). When there are no ACLs, we might as well use the in memory tree.