### PR TITLE
chore: remove Node version check

### DIFF
--- a/bin/signalk-server
+++ b/bin/signalk-server
@@ -16,8 +16,6 @@
  * limitations under the License.
 */
 
-require('please-upgrade-node')(require('../package.json'))
-
 var Server = require('../lib');
 var server = new Server();
 

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
     "node-fetch": "^2.2.0",
     "node-gpsd": "^0.3.0",
     "pem": "^1.11.0",
-    "please-upgrade-node": "^3.0.1",
     "primus": "^7.0.0",
     "semver": "^6.0.0",
     "spdy": "^4.0.0",


### PR DESCRIPTION
Prior to Node 6 or something people frequently tried to run with
extremely old versions of Node, which resulted in not very useful
error messages. Now that we are moving to 10 in #830, but everything still
works on 8, we don't want to force upgrading and create a support
storm. So let's drop the version requirement and see what the response is.