### PR TITLE
chore: remove requirement for node v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": "10"
+    "node": "8"
   },
   "dependencies": {
     "@signalk/freeboard-sk": "^1.0.0",


### PR DESCRIPTION

Let's not break installations that are currently running node 8. 

Per @tkurki, we should add a notification in the UI to ask people to update to node v10.
