### PR TITLE
[WIP] Wait for interfaces

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,33 +19,33 @@ if (typeof [].includes !== 'function') {
   process.exit(-1)
 }
 
-const express = require('express'),
-  _ = require('lodash'),
-  debug = require('debug')('signalk-server'),
-  DeltaCache = require('./deltacache'),
-  path = require('path'),
-  http = require('http'),
-  spdy = require('spdy'),
-  fs = require('fs'),
-  FullSignalK = require('@signalk/signalk-schema').FullSignalK,
-  { StreamBundle } = require('./streambundle'),
-  SubscriptionManager = require('./subscriptionmanager'),
-  Mode = require('stat-mode'),
-  page = require('./page'),
-  ports = require('./ports'),
-  getPrimaryPort = ports.getPrimaryPort,
-  getSecondaryPort = ports.getSecondaryPort,
-  getExternalPort = ports.getExternalPort,
-  {
-    startSecurity,
-    getCertificateOptions,
-    getSecurityConfig,
-    saveSecurityConfig
-  } = require('./security.js'),
-  { startDeltaStatistics, incDeltaStatistics } = require('./deltastats'),
-  DeltaChain = require('./deltachain'),
-  { getLatestServerVersion } = require('./modules'),
-  compareVersions = require('compare-versions')
+const express = require('express')
+const _ = require('lodash')
+const debug = require('debug')('signalk-server')
+const DeltaCache = require('./deltacache')
+const path = require('path')
+const http = require('http')
+const spdy = require('spdy')
+const fs = require('fs')
+const FullSignalK = require('@signalk/signalk-schema').FullSignalK
+const { StreamBundle } = require('./streambundle')
+const SubscriptionManager = require('./subscriptionmanager')
+const Mode = require('stat-mode')
+const page = require('./page')
+const ports = require('./ports')
+const getPrimaryPort = ports.getPrimaryPort
+const getSecondaryPort = ports.getSecondaryPort
+const getExternalPort = ports.getExternalPort
+const {
+  startSecurity,
+  getCertificateOptions,
+  getSecurityConfig,
+  saveSecurityConfig
+} = require('./security.js')
+const { startDeltaStatistics, incDeltaStatistics } = require('./deltastats')
+const DeltaChain = require('./deltachain')
+const { getLatestServerVersion } = require('./modules')
+const compareVersions = require('compare-versions')
 
 function Server (opts) {
   const FILEUPLOADSIZELIMIT = process.env.FILEUPLOADSIZELIMIT || '10mb'
@@ -286,32 +286,33 @@ Server.prototype.start = function () {
       debug('ID type: ' + app.selfType)
       debug('ID: ' + app.selfId)
 
-      startInterfaces(app)
-      startMdns(app)
-      app.providers = require('./pipedproviders')(app).start()
+      startInterfaces(app).then(() => {
+        startMdns(app)
+        app.providers = require('./pipedproviders')(app).start()
 
-      const primaryPort = getPrimaryPort(app)
-      debug(`primary port:${primaryPort}`)
-      server.listen(primaryPort, function () {
-        console.log(
-          'signalk-server running at 0.0.0.0:' + primaryPort.toString() + '\n'
-        )
-        app.started = true
-        resolve(self)
-      })
-      const secondaryPort = getSecondaryPort(app)
-      debug(`secondary port:${primaryPort}`)
-      if (app.config.settings.ssl && secondaryPort) {
-        startRedirectToSsl(
-          secondaryPort,
-          getExternalPort(app),
-          (err, server) => {
-            if (!err) {
-              app.redirectServer = server
+        const primaryPort = getPrimaryPort(app)
+        debug(`primary port:${primaryPort}`)
+        server.listen(primaryPort, function () {
+          console.log(
+            'signalk-server running at 0.0.0.0:' + primaryPort.toString() + '\n'
+          )
+          app.started = true
+          resolve(self)
+        })
+        const secondaryPort = getSecondaryPort(app)
+        debug(`secondary port:${primaryPort}`)
+        if (app.config.settings.ssl && secondaryPort) {
+          startRedirectToSsl(
+            secondaryPort,
+            getExternalPort(app),
+            (err, server) => {
+              if (!err) {
+                app.redirectServer = server
+              }
             }
-          }
-        )
-      }
+          )
+        }
+      })
     })
   })
 }
@@ -371,6 +372,7 @@ function startMdns (app) {
 }
 
 function startInterfaces (app) {
+  const interfacesStarts = []
   debug('Interfaces config:' + JSON.stringify(app.config.settings.interfaces))
   const availableInterfaces = require('./interfaces')
   _.forIn(availableInterfaces, function (_interface, name) {
@@ -387,7 +389,7 @@ function startInterfaces (app) {
           !app.interfaces[name].forceInactive
         ) {
           debug("Starting interface '" + name + "'")
-          app.interfaces[name].data = app.interfaces[name].start()
+          interfacesStarts.push(app.interfaces[name].start())
         } else {
           debug("Not starting interface '" + name + "' by forceInactive")
         }
@@ -396,6 +398,7 @@ function startInterfaces (app) {
       debug("Not loading interface '" + name + "' because of configuration")
     }
   })
+  return Promise.all(interfacesStarts.filter(x => x))
 }
 
 Server.prototype.reload = function (mixed) {

--- a/lib/interfaces/plugins.js
+++ b/lib/interfaces/plugins.js
@@ -36,7 +36,7 @@ module.exports = function (app) {
   const onStopHandlers = {}
   return {
     start: function () {
-      startPlugins(app)
+      const pluginStartPromises = startPlugins(app)
 
       ensureExists(path.join(app.config.configPath, 'plugin-config-data'))
 
@@ -87,6 +87,7 @@ module.exports = function (app) {
           })
         )
       })
+      return Promise.all(pluginStartPromises.filter(x => x))
     }
   }
 
@@ -149,7 +150,7 @@ module.exports = function (app) {
   function startPlugins (app) {
     app.plugins = []
     app.pluginsMap = {}
-    modulesWithKeyword(app, 'signalk-node-server-plugin').forEach(
+    return modulesWithKeyword(app, 'signalk-node-server-plugin').map(
       moduleData => {
         registerPlugin(
           app,
@@ -225,7 +226,7 @@ module.exports = function (app) {
   function registerPlugin (app, pluginName, metadata, location) {
     debug('Registering plugin ' + pluginName)
     try {
-      doRegisterPlugin(app, pluginName, metadata, location)
+      return doRegisterPlugin(app, pluginName, metadata, location)
     } catch (e) {
       console.error(e)
     }
@@ -262,19 +263,27 @@ module.exports = function (app) {
 
   function doPluginStart (app, plugin, location, configuration, restart) {
     debug('Starting plugin %s from %s', plugin.name, location)
+    let startP
     try {
       app.setProviderStatus(plugin.name, null)
-      plugin.start(configuration, restart)
-      debug('Started plugin ' + plugin.name)
+      startP = plugin.start(configuration, restart)
+      if (startP && startP.then) {
+        startP.then(() => debug(plugin.name + ' started'))
+      } else {
+        debug('Plugin start called ' + plugin.name)
+      }
       setPluginStartedMessage(plugin)
     } catch (e) {
       console.error('error starting plugin: ' + e)
       console.error(e.stack)
       app.setProviderError(plugin.name, `Failed to start: ${e.message}`)
     }
+    return startP
   }
 
   function doRegisterPlugin (app, packageName, metadata, location) {
+    let startP
+
     const appCopy = _.assign({}, app, {
       getSelfPath,
       getPath,
@@ -363,7 +372,7 @@ module.exports = function (app) {
     }
 
     if (startupOptions && startupOptions.enabled) {
-      doPluginStart(
+      startP = doPluginStart(
         app,
         plugin,
         location,
@@ -425,6 +434,8 @@ module.exports = function (app) {
     if (typeof plugin.signalKApiRoutes === 'function') {
       app.use('/signalk/v1/api', plugin.signalKApiRoutes(express.Router()))
     }
+
+    return startP
   }
 }
 

--- a/lib/interfaces/tcp.js
+++ b/lib/interfaces/tcp.js
@@ -74,23 +74,25 @@ module.exports = function (app) {
       })
     })
 
-    server.on('listening', () =>
-      debug('Signal K tcp server listening on ' + port)
-    )
     server.on('error', e => {
       console.error(`Signal K tcp server error: ${e.message}`)
     })
 
-    if (process.env.TCPSTREAMADDRESS) {
-      debug('Binding to ' + process.env.TCPSTREAMADDRESS)
-      server.listen(port, process.env.TCPSTREAMADDRESS)
-    } else {
-      server.listen(port)
-    }
-    debug('Tcp delta server listening on ' + port)
-    return {
-      port: port
-    }
+    return new Promise((resolve, reject) => {
+      if (process.env.TCPSTREAMADDRESS) {
+        debug('Binding to ' + process.env.TCPSTREAMADDRESS)
+        server.listen(port, process.env.TCPSTREAMADDRESS)
+      } else {
+        server.listen(port, err => {
+          if (err) {
+            reject(err)
+          } else {
+            debug('Tcp delta server listening on ' + port)
+            resolve()
+          }
+        })
+      }
+    })
   }
 
   api.stop = function () {


### PR DESCRIPTION
We don't want providers to start before interfaces, especially plugins,
are started and are ready to handle incoming data.

With this change interfaces and individual plugins can return
a Promise that must be resolved when it has started.

Any failing Promise will interrupt the server's startup - this is
probably not what we want?