### PR TITLE
Disable caching in express server for webapps

### DIFF
--- a/lib/interfaces/webapps.js
+++ b/lib/interfaces/webapps.js
@@ -38,7 +38,10 @@ function mountWebapps (app) {
       webappPath += '/public/'
     }
     debug('Mounting webapp /' + moduleData.module + ':' + webappPath)
-    app.use('/' + moduleData.module, express.static(webappPath))
+    app.use(
+      '/' + moduleData.module,
+      express.static(webappPath, { lastModified: false, etag: false })
+    )
     app.webapps.push(moduleData.metadata)
   })
 }


### PR DESCRIPTION
NPM Seems to pack all builds with Oct 26 1985 as the timestamp on files. Express server/Firefox use last time modified in their headers for caching. This can cause an updated app to not be served, as server returns "304 Not modified" and browser uses cached version.

Etag also needs to be disabled, (Etag is like fingerprint, also used to determine if client has latest version). For some reason Etag doesn't change when updating? Not sure what express is basing their fingerprint on?

Disabling these two mechanisms disables caching, though shouldn't really impact anything as we are not really serving high volume of requests from this interface...