### PR TITLE
fix: improve dnssd error handling

### DIFF
--- a/lib/mdns.js
+++ b/lib/mdns.js
@@ -109,6 +109,10 @@ module.exports = function mdnsResponder (app) {
         type.port
     )
     const ad = new mdns.Advertisement(type.type, type.port, options)
+    ad.on('error', err => {
+      console.log(type.type.name)
+      console.error(err)
+    })
     ad.start()
     ads.push(ad)
   }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "debug": "^4.1.0",
     "deep-get-set": "^1.1.0",
     "dev-null-stream": "0.0.1",
-    "dnssd": "^0.4.1",
+    "dnssd": "tkurki/dnssd.js#44b1347e728e2445f07c5f1aa97e00d2a89be0be",
     "errorhandler": "^1.3.0",
     "express": "^4.10.4",
     "express-namespace": "^0.1.1",


### PR DESCRIPTION
Handle errors from dsnsd Advertisements and use a version of
dnssd that does not throw out of band errors. Once
or if https://github.com/DeMille/dnssd.js/pull/13 or something
equivalent makes it to npm we should go back to the
upstream version of dnssd.

Fixes #850 