### PR TITLE
fix:"Advanced configuration has been deprecated" Validation error on …

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,24 +13,22 @@
     "lint": "eslint lib/ test/ --fix"
   },
   "lint-staged": {
-    "linters": {
-      "lib/**/*.js*": [
-        "prettier-standard",
-        "git add"
-      ],
-      "providers/*.js*": [
-        "prettier-standard",
-        "git add"
-      ],
-      "test/*.js*": [
-        "prettier-standard",
-        "git add"
-      ],
-      "index.js": [
-        "prettier-standard",
-        "git add"
-      ]
-    }
+    "lib/**/*.js*": [
+      "prettier-standard",
+      "git add"
+    ],
+    "providers/*.js*": [
+      "prettier-standard",
+      "git add"
+    ],
+    "test/*.js*": [
+      "prettier-standard",
+      "git add"
+    ],
+    "index.js": [
+      "prettier-standard",
+      "git add"
+    ]
   },
   "bin": {
     "signalk-server": "./bin/signalk-server",


### PR DESCRIPTION
Fix error since #845 (chore(package): update lint-staged to version 9.2.1):
```
husky > pre-commit (node v10.16.3)
Could not parse lint-staged config.
        Error: ● Validation Error:
Invalid value for 'linters'.
Advanced configuration has been deprecated. For more info, please visit: https://github.com/okonet/lint-staged.
```