### PR TITLE
chore: serialport@7.1.5 for Node 12 compatibility

### DIFF
--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalk/streams",
-  "version": "1.3.2",
+  "version": "1.4.1",
   "description": "Utilities for handling streams of Signal K data",
   "main": "index.js",
   "scripts": {
@@ -35,6 +35,6 @@
     "stream-throttle": "^0.1.3"
   },
   "optionalDependencies": {
-    "serialport": "^7.0.2"
+    "serialport": "^7.1.5"
   }
 }


### PR DESCRIPTION
Serialport 7.1.5 is supposed to be compatible with Node 12,
so let's upgrade to that to skip the ugly compile fails that
people experience with Node 12.

We are not supporting officially Node 12 though.

https://github.com/serialport/node-serialport/issues/1742#issuecomment-487292061