### PR TITLE
fix: tests globbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "create-release": "github-create-release --owner signalk --repository signalk-server-node --npm-base-url https://www.npmjs.com/package/signalk-server",
     "release": "git tag -d v$npm_package_version ;git tag v$npm_package_version && git push --tags && git push && git tag -d latest && git push origin :refs/tags/latest && git tag latest && git push origin tag latest && npm run create-release",
     "start": "node bin/signalk-server",
-    "test-only": "mocha --timeout 10000 --exit ./test/**/*.js ./lib/**/*.test.js",
+    "test-only": "mocha --timeout 10000 --exit 'test/**/*.js' 'lib/**/*.test.js'",
     "test": "npm run build && npm run test-only && npm run lint",
     "typedoc": "typedoc",
     "postinstall": "tsc",


### PR DESCRIPTION
Globs were not quoted and thus not handled correctly. See
https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784

modules.test.js was ignored inadvertedly by this.