### PR TITLE
feature: support prerelease versions

### DIFF
--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -78,7 +78,7 @@ module.exports = function(app) {
       app.get('/appstore/available/', (req, res) => {
         findPluginsAndWebapps()
           .then(([plugins, webapps]) => {
-            getLatestServerVersion().then(serverVersion => {
+            getLatestServerVersion(app.config.version).then(serverVersion => {
               const result = getAllModuleInfo(plugins, webapps, serverVersion)
               res.send(JSON.stringify(result))
             })

--- a/src/modules.test.js
+++ b/src/modules.test.js
@@ -2,7 +2,11 @@ const chai = require('chai')
 const _ = require('lodash')
 const fs = require('fs')
 const path = require('path')
-const { modulesWithKeyword } = require('./modules')
+const {
+  modulesWithKeyword,
+  checkForNewServerVersion,
+  getLatestServerVersion
+} = require('./modules')
 
 const expectedModules = [
   '@signalk/freeboard-sk',
@@ -51,5 +55,131 @@ describe('modulesWithKeyword', () => {
     chai.expect(_.map(moduleList, 'module')).to.eql(expectedModules)
     chai.expect(moduleList[0].location).to.not.eql(tempNodeModules)
     chai.expect(moduleList[2].location).to.eql(tempNodeModules)
+  })
+})
+
+describe('checkForNewServerVersion', () => {
+  it('normal version upgrade', done => {
+    checkForNewServerVersion(
+      '1.17.0',
+      (err, newVersion) => {
+        if (err) {
+          done(err)
+        } else {
+          chai.expect(newVersion).to.equal('1.18.0')
+          done()
+        }
+      },
+      () => Promise.resolve('1.18.0')
+    )
+  })
+
+  it('normal version does not upgrade to beta', done => {
+    checkForNewServerVersion(
+      '1.17.0',
+      err => {
+        done('callback should not be called')
+      },
+      () => Promise.resolve('1.18.0-beta.1')
+    )
+    done()
+  })
+
+  it('beta upgrades to same minor newer beta', done => {
+    checkForNewServerVersion(
+      '1.18.0-beta.1',
+      (err, newVersion) => {
+        if (err) {
+          done(err)
+        } else {
+          chai.expect(newVersion).to.equal('1.18.0-beta.2')
+          done()
+        }
+      },
+      () => Promise.resolve('1.18.0-beta.2')
+    )
+  })
+
+  it('beta upgrades to same normal version', done => {
+    checkForNewServerVersion(
+      '1.18.0-beta.2',
+      (err, newVersion) => {
+        if (err) {
+          done(err)
+        } else {
+          chai.expect(newVersion).to.equal('1.18.0')
+          done()
+        }
+      },
+      () => Promise.resolve('1.18.0')
+    )
+  })
+
+  it('beta upgrades to newer normal version', done => {
+    checkForNewServerVersion(
+      '1.18.0-beta.2',
+      (err, newVersion) => {
+        if (err) {
+          done(err)
+        } else {
+          chai.expect(newVersion).to.equal('1.19.0')
+          done()
+        }
+      },
+      () => Promise.resolve('1.19.0')
+    )
+  })
+
+  it('beta does not upgrade to newer minor beta', done => {
+    checkForNewServerVersion(
+      '1.17.0-beta.1',
+      err => {
+        done('callback should not be called')
+      },
+      () => Promise.resolve('1.18.0-beta.2')
+    )
+    done()
+  })
+})
+
+describe('getLatestServerVersion', () => {
+  it('latest for normal is normal', () => {
+    return getLatestServerVersion('1.17.0', () =>
+      Promise.resolve({
+        json: () => ({
+          latest: '1.18.3',
+          beta: '1.19.0-beta.1'
+        })
+      })
+    ).then(newVersion => {
+      chai.expect(newVersion).to.equal('1.18.3')
+    })
+  })
+
+  it('latest for beta is newer same series beta', done => {
+    getLatestServerVersion('1.18.0-beta.2', () =>
+      Promise.resolve({
+        json: () => ({
+          latest: '1.17.3',
+          beta: '1.18.0-beta.3'
+        })
+      })
+    ).then(newVersion => {
+      chai.expect(newVersion).to.equal('1.18.0-beta.3')
+      done()
+    })
+  })
+
+  it('latest for beta is newer real release', () => {
+    return getLatestServerVersion('1.18.0-beta.2', () =>
+      Promise.resolve({
+        json: () => ({
+          latest: '1.18.0',
+          beta: '1.18.0-beta.3'
+        })
+      })
+    ).then(newVersion => {
+      chai.expect(newVersion).to.equal('1.18.0')
+    })
   })
 })


### PR DESCRIPTION
The idea:
- a user can opt-in to a beta version
- an installed beta will keep upgrading to newer, same version
  betas, like  1.0.0-beta.1 => 1.0.0-beta.2
- an installed beta will upgrade to newer release versions
- once back in a release version the user needs to opt-in to beta again

Fixes #885.