### PR TITLE
chore: use dnssd2

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "debug": "^4.1.0",
     "deep-get-set": "^1.1.0",
     "dev-null-stream": "0.0.1",
-    "dnssd": "tkurki/dnssd.js#44b1347e728e2445f07c5f1aa97e00d2a89be0be",
+    "dnssd2": "1.0.0",
     "errorhandler": "^1.3.0",
     "express": "^4.10.4",
     "express-namespace": "^0.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -364,7 +364,7 @@ function startMdns(app) {
     try {
       app.interfaces.mdns = require('./mdns')(app)
     } catch (ex) {
-      debug('Could not start mDNS:' + ex)
+      console.error('Could not start mDNS:' + ex)
     }
   } else {
     debug(`Interface 'mDNS' was disabled in configuration`)

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -18,7 +18,7 @@
 
 const _ = require('lodash')
 const debug = require('debug')('signalk-server:interfaces:mdns')
-const dnssd = require('dnssd')
+const dnssd = require('dnssd2')
 const ports = require('./ports')
 
 module.exports = function mdnsResponder(app) {


### PR DESCRIPTION
Apparently dnssd is abandoned, so published dnssd2.