### PR TITLE
fix: do not fail in postinstall if tsc is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test-only": "mocha --timeout 10000 --exit 'test/**/*.js' 'lib/**/*.test.js'",
     "test": "npm run build && npm run test-only && npm run lint",
     "typedoc": "typedoc",
-    "postinstall": "tsc",
+    "postinstall": "([ ! -d 'lib' ] && tsc) || true",
     "heroku-postbuild": "npm install @signalk/simple-gpx"
   },
   "bin": {


### PR DESCRIPTION
npm install -g signalk-server will install only prod deps,
so tsc won't be there, but lib is already built during publish,
so no need for it either.