### PR TITLE
feature: more failure tolerant appstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "minimist": "^1.1.0",
     "moment": "^2.10.6",
     "morgan": "^1.5.0",
-    "node-fetch": "^2.2.0",
+    "node-fetch": "^2.6.0",
     "node-gpsd": "^0.3.0",
     "pem": "^1.11.0",
     "primus": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,8 @@
     "@signalk/github-create-release": "^1.0.0",
     "@types/express": "^4.17.1",
     "@types/lodash": "^4.14.139",
+    "@types/node-fetch": "^2.5.3",
+    "@types/semver": "^6.2.0",
     "chai": "^4.0.0",
     "chai-things": "^0.2.0",
     "freeport-promise": "^1.0.0",

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -78,10 +78,17 @@ module.exports = function(app) {
       app.get('/appstore/available/', (req, res) => {
         findPluginsAndWebapps()
           .then(([plugins, webapps]) => {
-            getLatestServerVersion(app.config.version).then(serverVersion => {
-              const result = getAllModuleInfo(plugins, webapps, serverVersion)
-              res.send(JSON.stringify(result))
-            })
+            getLatestServerVersion(app.config.version)
+              .then(serverVersion => {
+                const result = getAllModuleInfo(plugins, webapps, serverVersion)
+                res.send(JSON.stringify(result))
+              })
+              .catch(err => {
+                //could be that npmjs is down, so we can not get
+                //server version, but we have app store data
+                const result = getAllModuleInfo(plugins, webapps, '0.0.0')
+                res.send(JSON.stringify(result))
+              })
           })
           .catch(error => {
             if (error.code === 'ENOTFOUND') {

--- a/src/interfaces/plugins.ts
+++ b/src/interfaces/plugins.ts
@@ -142,14 +142,18 @@ module.exports = (theApp: any) => {
               return plugin.name
             }
           ]).map((plugin: PluginInfo) => {
-            let data = null
+            let data: { enabled: boolean } | null = null
             try {
               data = getPluginOptions(plugin.id)
             } catch (e) {
               console.log(e.code + ' ' + e.path)
             }
 
-            if (_.isUndefined(data.enabled) && plugin.enabledByDefault) {
+            if (
+              data &&
+              _.isUndefined(data.enabled) &&
+              plugin.enabledByDefault
+            ) {
               data.enabled = true
             }
 


### PR DESCRIPTION
Appstore uses two registries. Now one can fail
and the store will still work with data from the
working one. The server waits for 5 seconds for the
slower registry to return and if not in time uses data
from the quicker one. The latest server version is
available only from npmjs - if it is not answering
the server check fails silently with nothing in the
ui.

Resolves #892.

Converts modules.js to TypeScript and bumps node-fetch to 2.6.0.