### PR TITLE
chore: remove linux-specific postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ To generate your own vessel settings file and configure your Pi to start the ser
 git clone https://github.com/SignalK/signalk-server-node.git
 cd signalk-server-node
 npm install
+npm run build
 ```
 
 Start the server with sample data:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "test-only": "mocha --timeout 10000 --exit 'test/**/*.js' 'lib/**/*.test.js'",
     "test": "npm run build && npm run test-only && npm run lint",
     "typedoc": "typedoc",
-    "postinstall": "([ ! -d 'lib' ] && tsc) || true",
     "heroku-postbuild": "npm install @signalk/simple-gpx"
   },
   "bin": {


### PR DESCRIPTION
The postinstall script is not compatible with windows,
so it causes npm install to fail needlessly. Let's just
remove it - anybody installing with git should be savvy enough
to be able to build the server.