### PR TITLE
Feature: disable server update when in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,5 @@ RUN npm run build
 RUN mkdir -p /home/node/.signalk
 
 EXPOSE 3000
+ENV IS_IN_DOCKER true
 ENTRYPOINT /home/node/signalk/bin/signalk-server --securityenabled

--- a/README.md
+++ b/README.md
@@ -64,7 +64,18 @@ wscat 'ws://localhost:3000/signalk/v1/stream?subscribe=all'
 
 ## Use: Run on Docker
 
-You can start a local server on port 3000  with `docker run --name signalk-server --publish 3000:3000 --entrypoint signalk-server signalk/signalk-server-node:latest --sample-nmea0183-data`. Docker is currently aimed at running a local demo server that you can test against, not for real use.
+You can start a local server on port 3000  with demo data with
+
+```
+docker run --name signalk-server --publish 3000:3000 --entrypoint signalk-server signalk/signalk-server-node:latest --sample-nmea0183-data
+```
+
+For real use the easiest way is mount HOME/.signalk from the host and run priviledged so that the container has access to host's /dev under /dev/hostdev:
+
+```
+docker run --name signalk-server --publish 3000:3000 -v --privileged -v $HOME/.signalk:/home/node/.signalk -v /dev:/dev/hostdev signalk/signalk-server-node
+```
+
 
 Now what?
 ---------

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@signalk/maptracker": "^1.0.0",
     "@signalk/playground": "^1.0.0",
     "@signalk/sailgauge": "^1.1.0",
-    "@signalk/server-admin-ui": "~1.13.0",
+    "@signalk/server-admin-ui": "~1.14.0",
     "@signalk/set-system-time": "^1.2.0",
     "@signalk/signalk-schema": "1.3.1",
     "@signalk/signalk-to-nmea0183": "^1.0.0",

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signalk/server-admin-ui",
-  "version": "1.12.1",
+  "version": "1.14.0",
   "description": "Signal K server admin webapp",
   "author": "Scott Bender, Teppo Kurki",
   "contributors": [

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -30,7 +30,7 @@
     "history": "4.7.2",
     "html-loader": "0.5.1",
     "html-webpack-plugin": "2.30.1",
-    "node-sass": "4.7.1",
+    "node-sass": "^4.13.0",
     "react": "16.1.1",
     "react-chartjs-2": "2.6.4",
     "react-dom": "16.1.1",

--- a/packages/server-admin-ui/package.json
+++ b/packages/server-admin-ui/package.json
@@ -49,7 +49,7 @@
     "style-loader": "0.19.0",
     "uglify-js": "3.1.10",
     "url-loader": "0.6.2",
-    "webpack": "^3.8.1",
+    "webpack": "3.8.1",
     "webpack-dev-server": "2.9.4"
   },
   "scripts": {

--- a/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/PluginConfigurationForm.js
@@ -1,7 +1,4 @@
 import React, { Component } from 'react'
-import { render } from 'react-dom'
-import keys from 'lodash.keys'
-
 import Form from 'react-jsonschema-form-bs4'
 
 

--- a/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/ServerUpdate.js
@@ -54,7 +54,15 @@ class ServerUpdate extends Component {
           <Card className='border-warning'>
             <CardHeader>Server Update</CardHeader>
             <CardBody>
-            This installation is not updatable.
+            This installation is not updatable from the admin user interface.
+            </CardBody>
+          </Card>
+        )}
+        {this.props.appStore.isInDocker && (
+          <Card className='border-warning'>
+            <CardHeader>Running as a Docker container</CardHeader>
+            <CardBody>
+              The server is running as a Docker container. You need to pull a new server version from <a href="https://hub.docker.com/r/signalk/signalk-server/tags">Docker Hub</a> to update.
             </CardBody>
           </Card>
         )}

--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -92,13 +92,7 @@ module.exports = function(app) {
           })
           .catch(error => {
             if (error.code === 'ENOTFOUND') {
-              res.send({
-                available: [],
-                installed: [],
-                updates: [],
-                installing: [],
-                storeAvailable: false
-              })
+              res.send(emptyAppStoreInfo())
             }
             console.log(error)
             console.error(error.message)
@@ -126,21 +120,26 @@ module.exports = function(app) {
     return app.webapps.find(webapp => webapp.name === id)
   }
 
-  function getAllModuleInfo(plugins, webapps, serverVersion) {
-    const all = {
+  function emptyAppStoreInfo() {
+    return {
       available: [],
       installed: [],
       updates: [],
       installing: [],
-      storeAvailable: true
+      storeAvailable: true,
+      isInDocker: process.env.IS_IN_DOCKER === 'true'
     }
+  }
+
+  function getAllModuleInfo(plugins, webapps, serverVersion) {
+    const all = emptyAppStoreInfo()
 
     if (
       process.argv.length > 1 &&
       npmServerInstallLocations.includes(process.argv[1]) &&
       !process.env.SIGNALK_DISABLE_SERVER_UPDATES
     ) {
-      all.canUpdateServer = true
+      all.canUpdateServer = !all.isInDocker && true
       if (compareVersions(serverVersion, app.config.version) > 0) {
         all.serverUpdate = serverVersion
 


### PR DESCRIPTION
A server running inside docker is not really updateable, as one
should pull a new image, not try to run update inside the container.
Which will not work anyway, because inside the container the
installation is not from npm.

So disable update from the admin ui and show an extra message
for Docker users. This will work with only the official images
with IS_IN_DOCKER set to true, but if you build your own image
you're on your own anyway.

Fixes #901.