### PR TITLE
Feature: improve serial port handling

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -129,7 +129,7 @@ class DeviceInput extends Component {
   constructor(props) {
     super()
     this.state = {
-      devices: [props.value.device]
+      devices: []
     }
   }
 
@@ -139,17 +139,20 @@ class DeviceInput extends Component {
     })
       .then(response => response.json())
       .then(data => {
-        //make sure that the configured device is
-        //an option to be the selected on in the select,
-        //as it may be unplugged or unavailable
-        if (data.indexOf(this.props.value.device) == -1) {
-          data.push(this.props.value.device)
-        }
-        this.setState({ devices: data })
+        this.setState({
+          devices: data
+        })
       })
   }
 
   render () {
+    const isManualEntry = !this.state.devices.includes(this.props.value.device)
+    let manualEntryValue = isManualEntry
+      ? this.props.value.device === 'Enter manually'
+        ? ''
+        : this.props.value.device
+      : ''
+    const fixedEntries = ['Enter manually', '-']
     return (
       <FormGroup row>
         <Col md='2'>
@@ -161,9 +164,9 @@ class DeviceInput extends Component {
             name="options.device"
             id="serialportselect"
             onChange={this.props.onChange}
-            value={this.props.value.device}>
-              {this.state.devices.map((device, i) => (
-                <option key={i}>{device}</option>
+            value={isManualEntry ? 'Enter manually' : this.props.value.device}>
+              {fixedEntries.concat(this.state.devices).map((device, i) => (
+                <option disabled={device === '-'}key={i}>{device}</option>
               ))}
           </Input>
         </Col>
@@ -171,7 +174,8 @@ class DeviceInput extends Component {
           <Input
               type='text'
               name='options.device'
-              value={this.props.value.device}
+              disabled={!isManualEntry}
+              value={manualEntryValue}
               onChange={event => this.props.onChange(event)}
             />
         </Col>

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -129,7 +129,7 @@ class DeviceInput extends Component {
   constructor(props) {
     super()
     this.state = {
-      devices: []
+      devices: {}
     }
   }
 
@@ -146,13 +146,12 @@ class DeviceInput extends Component {
   }
 
   render () {
-    const isManualEntry = !this.state.devices.includes(this.props.value.device)
+    const isManualEntry = !isListedDevice(this.props.value.device, this.state.devices)
     let manualEntryValue = isManualEntry
       ? this.props.value.device === 'Enter manually'
         ? ''
         : this.props.value.device
       : ''
-    const fixedEntries = ['Enter manually', '-']
     return (
       <FormGroup row>
         <Col md='2'>
@@ -164,24 +163,47 @@ class DeviceInput extends Component {
             name="options.device"
             id="serialportselect"
             onChange={this.props.onChange}
-            value={isManualEntry ? 'Enter manually' : this.props.value.device}>
-              {fixedEntries.concat(this.state.devices).map((device, i) => (
-                <option disabled={device === '-'}key={i}>{device}</option>
-              ))}
+            value={isManualEntry ? 'Enter manually' : this.props.value.device}
+          >
+            <option key="enterManually">Enter manually</option>
+            {serialportListOptions(
+              ['byOpenPlotter', 'byId', 'byPath', 'serialports'],
+              ['OpenPlotter managed:', 'by-id:', 'by-path:', 'Listed:'],
+              this.state.devices
+            )}
           </Input>
         </Col>
         <Col xs='12' md='3'>
           <Input
-              type='text'
-              name='options.device'
-              disabled={!isManualEntry}
-              value={manualEntryValue}
-              onChange={event => this.props.onChange(event)}
-            />
+            type="text"
+            name="options.device"
+            disabled={!isManualEntry}
+            value={manualEntryValue || ''}
+            onChange={event => this.props.onChange(event)}
+          />
         </Col>
       </FormGroup>
     )
   }
+}
+
+const isListedDevice = (device, deviceListMap) => {
+  const list = Object.keys(deviceListMap).reduce((acc, key) => {
+    return acc.concat(deviceListMap[key])
+  }, [])
+  return list.includes(device)
+}
+
+const serialportListOptions = (keys, labels, deviceListMap) => {
+  return keys.reduce((acc, key, j) => {
+    if (deviceListMap[key] && deviceListMap[key].length > 0) {
+      acc.push(<option disabled="true" key={key}>{labels[j]}</option>)
+      deviceListMap[key].forEach((device, i) => {
+        acc.push(<option key={`${key}${i}`}>{device}</option>)
+      })
+    }
+    return acc
+  },[])
 }
 
 class LoggingInput extends Component {

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -539,11 +539,14 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
   app.get('/serialports', (req, res, next) => {
     Promise.all([
       listSafeSerialPortsDevSerialById(),
+      listSafeSerialPortsDevSerialByPath(),
       listSafeSerialPortsOpenPlotter(),
       listSerialPorts()
     ])
-    .then(([a, b, c]) => res.json(a.concat(b).concat(c)))
-    .catch(next)
+      .then(([byId, byPath, byOpenPlotter, serialports]) =>
+        res.json({ byId, byPath, byOpenPlotter, serialports })
+      )
+      .catch(next)
   })
 
   function listSerialPorts() {
@@ -557,6 +560,14 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
       .catch(err => [])
       .then(filenames =>
         filenames.map(filename => `/dev/serial/by-id/${filename}`)
+      )
+  }
+
+  function listSafeSerialPortsDevSerialByPath() {
+    return readdir('/dev/serial/by-path')
+      .catch(err => [])
+      .then(filenames =>
+        filenames.map(filename => `/dev/serial/by-path/${filename}`)
       )
   }
 


### PR DESCRIPTION
Fix the dead stupid serial port selection UI:
- add _Enter manually_ selection to the popup menu
- the text field is enabled only when the user has chosen manual entry
- manual entry is implicitly chosen if the serial port listing retrieved from the server does not contain the path saved in the configuration

 List serial ports using four methods:
    - /dev/serial/by-id
    - /dev/serial/by-path
    - /dev/ttyOP_*
    - using serialport module
 
OpenPlotter 2 has a serial port manager that allows the user to rename serial ports with symbolic names using udev rules. On Linux there are already persistent names under by-id and lastly serialport works on at least MacOS and hopefully on Windows as well.

Fixes #880 .