### PR TITLE
feature: make default installed plugins optional dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,18 +66,8 @@
     "node": "10"
   },
   "dependencies": {
-    "@signalk/freeboard-sk": "^1.0.0",
-    "@signalk/instrumentpanel": "0.x",
-    "@signalk/maptracker": "^1.0.0",
-    "@signalk/playground": "^1.0.0",
-    "@signalk/sailgauge": "^1.1.0",
     "@signalk/server-admin-ui": "~1.15.0",
-    "@signalk/set-system-time": "^1.2.0",
     "@signalk/signalk-schema": "1.3.1",
-    "@signalk/signalk-to-nmea0183": "^1.0.0",
-    "@signalk/simplegauges": "^1.0.1",
-    "@signalk/streams": "~1.4.0",
-    "@signalk/zones": "^1.0.0",
     "@types/debug": "^4.1.5",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",
@@ -119,6 +109,18 @@
     "stat-mode": "^1.0.0",
     "uuid": "^3.2.1",
     "ws": "^7.0.0"
+  },
+  "optionalDependencies": {
+    "@signalk/freeboard-sk": "^1.0.0",
+    "@signalk/instrumentpanel": "0.x",
+    "@signalk/maptracker": "^1.0.0",
+    "@signalk/playground": "^1.0.0",
+    "@signalk/sailgauge": "^1.1.0",
+    "@signalk/set-system-time": "^1.2.0",
+    "@signalk/signalk-to-nmea0183": "^1.0.0",
+    "@signalk/simplegauges": "^1.0.1",
+    "@signalk/streams": "~1.4.0",
+    "@signalk/zones": "^1.0.0"
   },
   "devDependencies": {
     "@signalk/github-create-release": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@serialport/bindings": "^8.0.6",
     "@signalk/server-admin-ui": "~1.15.0",
     "@signalk/signalk-schema": "1.3.1",
-    "@signalk/streams": "^1.4.0",
+    "@signalk/streams": "~1.4.0",
     "@types/debug": "^4.1.5",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,10 @@
     "node": "10"
   },
   "dependencies": {
+    "@serialport/bindings": "^8.0.6",
     "@signalk/server-admin-ui": "~1.15.0",
     "@signalk/signalk-schema": "1.3.1",
+    "@signalk/streams": "^1.4.0",
     "@types/debug": "^4.1.5",
     "baconjs": "^1.0.1",
     "bcryptjs": "^2.4.3",
@@ -119,7 +121,6 @@
     "@signalk/set-system-time": "^1.2.0",
     "@signalk/signalk-to-nmea0183": "^1.0.0",
     "@signalk/simplegauges": "^1.0.1",
-    "@signalk/streams": "~1.4.0",
     "@signalk/zones": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This allows the use of the --no-optional npm install flag to get a minimal install with no default plugins