### PR TITLE
fix: increase ws MAXSENDBUFFERSIZE

### DIFF
--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -617,7 +617,7 @@ function startServerEvents(app, spark) {
 
 function getAssertBufferSize(config) {
   const MAXSENDBUFFERSIZE =
-    process.env.MAXSENDBUFFERSIZE || config.maxSendBufferSize || 512 * 1024
+    process.env.MAXSENDBUFFERSIZE || config.maxSendBufferSize || 4 * 512 * 1024
   debug(`MAXSENDBUFFERSIZE:${MAXSENDBUFFERSIZE}`)
 
   if (MAXSENDBUFFERSIZE === 0) {


### PR DESCRIPTION
With a lot of deltas the initial burst of data upon connection may
overflow the buffer limit and terminate ws connection. At
least that is the theory.