### PR TITLE
fix: invalid defaults.json gets ignored and overwritten

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -24,6 +24,7 @@ const uuidv4 = require('uuid/v4')
 const semver = require('semver')
 
 let disableWriteSettings = false
+let invalidDefaultsFile = false
 
 function load(app) {
   app.__argv = process.argv.slice(2)
@@ -219,7 +220,10 @@ function setFullDefaults(app) {
     if (e.code && e.code === 'ENOENT') {
       debug(`No defaults found at ${defaultsPath.toString()}`)
     } else {
-      console.log(e)
+      invalidDefaultsFile = true
+      console.error('unable to parse defaults.json')
+      console.error(e)
+      process.exit(1)
     }
     app.config.defaults = { vessels: { self: {} } }
   }
@@ -263,7 +267,7 @@ function setSelfSettings(app) {
   if (_.isUndefined(mmsi) && _.isUndefined(uuid)) {
     uuid = 'urn:mrn:signalk:uuid:' + uuidv4()
     _.set(app.config.defaults, 'vessels.self.uuid', uuid)
-    if (!disableWriteSettings) {
+    if (!disableWriteSettings && !invalidDefaultsFile) {
       writeDefaultsFile(app, app.config.defaults, err => {
         if (err) {
           console.error(`unable to write defaults file: ${err}`)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -24,7 +24,6 @@ const uuidv4 = require('uuid/v4')
 const semver = require('semver')
 
 let disableWriteSettings = false
-let invalidDefaultsFile = false
 
 function load(app) {
   app.__argv = process.argv.slice(2)
@@ -220,7 +219,6 @@ function setFullDefaults(app) {
     if (e.code && e.code === 'ENOENT') {
       debug(`No defaults found at ${defaultsPath.toString()}`)
     } else {
-      invalidDefaultsFile = true
       console.error(`unable to parse ${defaultsPath.toString()}`)
       console.error(e)
       process.exit(1)
@@ -267,7 +265,7 @@ function setSelfSettings(app) {
   if (_.isUndefined(mmsi) && _.isUndefined(uuid)) {
     uuid = 'urn:mrn:signalk:uuid:' + uuidv4()
     _.set(app.config.defaults, 'vessels.self.uuid', uuid)
-    if (!disableWriteSettings && !invalidDefaultsFile) {
+    if (!disableWriteSettings) {
       writeDefaultsFile(app, app.config.defaults, err => {
         if (err) {
           console.error(`unable to write defaults file: ${err}`)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -221,7 +221,7 @@ function setFullDefaults(app) {
       debug(`No defaults found at ${defaultsPath.toString()}`)
     } else {
       invalidDefaultsFile = true
-      console.error('unable to parse defaults.json')
+      console.error(`unable to parse ${defaultsPath.toString()}`)
       console.error(e)
       process.exit(1)
     }


### PR DESCRIPTION
If the defaults.json has syntax errors, the file is overwritten and the server starts up normally. 

This change makes so we log a good error message and fail to startup.