### PR TITLE
[WIP] feature: add support for history api plugin

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -165,6 +165,13 @@ module.exports = function(app) {
           }
         })
       })
+
+      if (app.historyProvider && app.historyProvider.registerHistoryApiRoute) {
+        debug('Adding history api route')
+        const historyApiRouter = express.Router()
+        app.historyProvider.registerHistoryApiRoute(historyApiRouter)
+        app.use(pathPrefix + versionPrefix + '/history', historyApiRouter)
+      }
     },
 
     mdns: {


### PR DESCRIPTION
Allow a historyProvider plugin to register under /signalk/v1/history/*.