### PR TITLE
fix: log2sk case sensitive file reference

### DIFF
--- a/bin/log2sk
+++ b/bin/log2sk
@@ -16,7 +16,7 @@ const app = {
 new require('../lib/pipedproviders')(app).createPipedProvider({
   pipeElements: [
     {
-      type: 'providers/Simple',
+      type: 'providers/simple',
       options: {
         logging: false,
         noThrottle: true,


### PR DESCRIPTION
log2sk worked only on case-insensitive file systems, like MacOS that
defaults to case-preserving but case-insensitive.

Fixes #948.