### PR TITLE
fix: useTLS vs useSSL with signalkClient

### DIFF
--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -40,7 +40,7 @@ function MdnsWs (options) {
     this.signalkClient = new SignalK.Client({
       hostname: options.host,
       port: options.port,
-      useSSL: options.type === 'wss',
+      useTLS: options.type === 'wss',
       reconnect: true,
       autoConnect: false,
     })


### PR DESCRIPTION
fix issue #964 (Cannot subscribe to Signal K stream non SSL/TLS)