### PR TITLE
fix: Allows SSL/TLS connection to server with self-signed certificate

### DIFF
--- a/bin/signalk-server
+++ b/bin/signalk-server
@@ -16,6 +16,9 @@
  * limitations under the License.
 */
 
+// Allows SSL/TLS connection to a server with a self-signed certificate
+process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
+
 var Server = require('../lib');
 var server = new Server();
 


### PR DESCRIPTION
Allows SSL/TLS connection to a server with a self-signed certificate
fix #965 (Cannot subscribe to SSL/TLS Signal K stream with self signed certificate).
Can also be fixed with `export NODE_TLS_REJECT_UNAUTHORIZED=0` in shell env before starting Signal K server.
