### PR TITLE
fix: use correct protocol with websocket

### DIFF
--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -40,7 +40,7 @@ function MdnsWs (options) {
     this.signalkClient = new SignalK.Client({
       hostname: options.host,
       port: options.port,
-      useTLS: options.type === 'wss',
+      useTLS: options.protocol === 'wss',
       reconnect: true,
       autoConnect: false,
     })


### PR DESCRIPTION
second fix for issue #964 (Cannot subscribe to Signal K stream non SSL/TLS)
use correct protocol with websocket.
Sorry, I fired too fast the first time and I didn't see the second mistake right next to it.