### PR TITLE
fix: do not check TLS certificate file permissions on win32

### DIFF
--- a/src/security.js
+++ b/src/security.js
@@ -149,7 +149,7 @@ function getCertificateOptions(app, cb) {
 
 function hasStrictPermissions(stat) {
   if (process.platform === 'win32') {
-    return new Mode(stat).toString() === '-r--r--r--'
+    return true
   } else {
     return /^-r[-w][-x]------$/.test(new Mode(stat).toString())
   }


### PR DESCRIPTION
On Windows the fs.stat function returns inconsistent values.
The checking of the SSL certificate file attributes has been removed on Windows only.
Fix issue #982 