### PR TITLE
fix: Emit sentenceEvents on both `app` and `app.signalk`

### DIFF
--- a/packages/streams/nmea0183-signalk.js
+++ b/packages/streams/nmea0183-signalk.js
@@ -45,7 +45,7 @@ function Nmea0183ToSignalK (options) {
   this.n2kState = {}
 
   // Object on which to send 'sentence' events
-  this.sentenceEventEmitter = options.app.signalk
+  this.sentenceEventEmitter = options.app
 
   // Prepare a list of events to send for each sentence received
   this.sentenceEvents = options.suppress0183event ? [] : ['nmea0183']
@@ -79,6 +79,7 @@ Nmea0183ToSignalK.prototype._transform = function (chunk, encoding, done) {
       // Send 'sentences' event to the app for each sentence
       this.sentenceEvents.forEach(eventName => {
         this.sentenceEventEmitter.emit(eventName, sentence)
+        this.sentenceEventEmitter.signalk.emit(eventName, sentence)
       })
 
       let delta = null

--- a/packages/streams/nmea0183-signalk.js
+++ b/packages/streams/nmea0183-signalk.js
@@ -16,7 +16,7 @@
 
 /**
  * Usage: this is the pipeElement that transforms NMEA0183 input to Signal K deltas.
- * Emits sentence data as "nmea0183" events on app.signalk by default.
+ * Emits sentence data as "nmea0183" events on app and app.signalk by default.
  * Furthermore you can use "sentenceEvent" option, that will cause sentence data to be
  * emitted as events on app. sentenceEvent can be a string or an array of strings.
  *
@@ -45,7 +45,7 @@ function Nmea0183ToSignalK (options) {
   this.n2kState = {}
 
   // Object on which to send 'sentence' events
-  this.sentenceEventEmitter = options.app
+  this.app = options.app
 
   // Prepare a list of events to send for each sentence received
   this.sentenceEvents = options.suppress0183event ? [] : ['nmea0183']
@@ -78,8 +78,8 @@ Nmea0183ToSignalK.prototype._transform = function (chunk, encoding, done) {
     if (sentence !== undefined) {
       // Send 'sentences' event to the app for each sentence
       this.sentenceEvents.forEach(eventName => {
-        this.sentenceEventEmitter.emit(eventName, sentence)
-        this.sentenceEventEmitter.signalk.emit(eventName, sentence)
+        this.app.emit(eventName, sentence)
+        this.app.signalk.emit(eventName, sentence)
       })
 
       let delta = null


### PR DESCRIPTION
This fixes a bug where sentenceEvents were emitted only on
`app.signalk`, but the toStdout configuration only allowed us to listen
on `app`. This fixes it by emitting on both, as discussed on Slack
earlier today.