### PR TITLE
feature: add vhf call sign to UI and make it configurable

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
@@ -109,8 +109,23 @@ class VesselConfiguration extends Component {
                     </FormText>
                   </Col>
                 </FormGroup>
-                
-                  <FormGroup row>
+                <FormGroup row>
+                  <Col md='2'>
+                    <Label htmlFor='callsignVhf'>Call Sign</Label>
+                  </Col>
+                  <Col xs='12' md='4'>
+                    <Input
+                      type='text'
+                      name='callsignVhf'
+                      onChange={this.handleChange}
+                      value={this.state.callsignVhf}
+                    />
+                    <FormText color='muted'>
+                      Leave blank if there is no call sign
+                    </FormText>
+                  </Col>
+                </FormGroup>
+                <FormGroup row>
                   <Col md='2'>
                     <Label htmlFor='uuid'>UUID</Label>
                   </Col>

--- a/src/serverroutes.js
+++ b/src/serverroutes.js
@@ -453,7 +453,8 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
       height: _.get(self, 'design.airHeight.value'),
       gpsFromBow: _.get(self, 'sensors.gps.fromBow.value'),
       gpsFromCenter: _.get(self, 'sensors.gps.fromCenter.value'),
-      aisShipType: _.get(self, 'design.aisShipType.value.id')
+      aisShipType: _.get(self, 'design.aisShipType.value.id'),
+      callsignVhf: _.get(self, 'communication.callsignVhf')
     }
 
     if (app.config.settings.vessel) {
@@ -532,6 +533,9 @@ module.exports = function(app, saveSecurityConfig, getSecurityConfig) {
         name: getAISShipTypeName(newVessel.aisShipType),
         id: Number(newVessel.aisShipType)
       })
+    }
+    if (newVessel.callsignVhf) {
+      set('communication.callsignVhf', newVessel.callsignVhf)
     }
 
     skConfig.writeDefaultsFile(app, data, err => {


### PR DESCRIPTION
Add VHF Call Sign to Vessel data as configurable parameter and make it available in /communication/callsignVhf. #1018