### PR TITLE
feature: add sendCachedValue ws query parameter

### DIFF
--- a/src/interfaces/ws.js
+++ b/src/interfaces/ws.js
@@ -595,7 +595,9 @@ function handleRealtimeConnection(app, spark, onChange) {
     app.signalk.removeListener('delta', onChange)
   })
 
-  sendLatestDeltas(app.deltaCache, app.selfContext, spark)
+  if (!(spark.request.query['sendCachedValues'] === 'false')) {
+    sendLatestDeltas(app.deltaCache, app.selfContext, spark)
+  }
 
   if (spark.query.serverevents === 'all') {
     spark.hasServerEvents = true


### PR DESCRIPTION
Add the option to suppress sending of latest values when
WebSocket connects. This can be done with query parameter
sendCachedValues=false. Any other value or no query parameter
with that name results in previous behavior, sending all
the relevant latest values as deltas.