### PR TITLE
fix: less logging from serial retries

### DIFF
--- a/packages/streams/serialport.js
+++ b/packages/streams/serialport.js
@@ -77,6 +77,7 @@ function SerialStream (options) {
   this.options = options
   this.maxPendingWrites = options.maxPendingWrites || 5
   this.start()
+  this.isFirstError = true
 }
 
 require('util').inherits(SerialStream, Transform)
@@ -110,6 +111,7 @@ SerialStream.prototype.start = function () {
         this.options.providerId,
         `Connected to ${this.options.device}`
       )
+      this.isFirstError = true
       this.options.app.setProviderError(this.options.providerId, '')
       const parser = new SerialPort.parsers.Readline()
       this.serial.pipe(parser).pipe(this)
@@ -120,7 +122,11 @@ SerialStream.prototype.start = function () {
     'error',
     function (x) {
       this.options.app.setProviderError(this.options.providerId, x.message)
-      console.log(x.message)
+      if (this.isFirstError) {
+        console.log(x.message)
+      }
+      debug(x.message)
+      this.isFirstError = false
       this.scheduleReconnect()
     }.bind(this)
   )


### PR DESCRIPTION
After this change only the first error related to each configured
serialport is logged to stderr. If the port is connected then
the first error is logged again. Errors related to retries
are logged only on debug level, with debug key signalk:serialport.