### PR TITLE
feature: add null removal and ignored sentences to 0183 input

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -286,6 +286,36 @@ class ValidateChecksumInput extends Component {
   }
 }
 
+class RemoveNullsInput extends Component {
+  constructor (props) {
+    super(props)
+    this.props.value.removeNulls =
+      this.props.value.removeNulls
+  }
+  render () {
+    return (
+      <FormGroup row>
+        <Col xs='3' md='2'>
+          <Label>Remove NULL characters</Label>
+        </Col>
+        <Col xs='2' md='3'>
+          <Label className='switch switch-text switch-primary'>
+            <Input
+              type='checkbox'
+              name='options.removeNulls'
+              className='switch-input'
+              onChange={event => this.props.onChange(event)}
+              checked={this.props.value.removeNulls}
+            />
+            <span className='switch-label' data-on='Yes' data-off='No' />
+            <span className='switch-handle' />
+          </Label>
+        </Col>
+      </FormGroup>
+    )
+  }
+}
+
 class SentenceEventInput extends Component {
   render () {
     return (
@@ -389,6 +419,39 @@ class StdOutInput extends Component {
         title='Output Events'
         name='options.toStdout'
         helpText='Events that should be written as output to this connection. Example: nmea0183,nmea0183out'
+        value={this.state.value}
+        onChange={this.onChange}
+      />
+    )
+  }
+}
+
+class IgnoredSentences extends Component {
+  constructor(props) {
+    super();
+    let value = props.value.ignoredSentences;
+    if(Array.isArray(value)) {
+      value = value.join(',');
+    }
+    this.state = {value}
+    this.onChange = this.onChange.bind(this);
+  }
+  onChange(e) {
+    this.setState({value: e.target.value});
+    this.props.onChange({
+      target: {
+        type: e.target.type,
+        name: e.target.name,
+        value: e.target.value.split(','),
+      }
+    });
+  }
+  render () {
+    return (
+      <TextInput
+        title='Ignored Sentences'
+        name='options.ignoredSentences'
+        helpText='NMEA0183 sentences to throw away from the input data. Example: RMC,ROT'
         value={this.state.value}
         onChange={this.onChange}
       />
@@ -576,6 +639,15 @@ const NMEA0183 = props => {
         value={props.value.options}
         onChange={props.onChange}
       />
+      <RemoveNullsInput
+        value={props.value.options}
+        onChange={props.onChange}
+      />
+      <IgnoredSentences
+        value={props.value.options}
+        onChange={props.onChange}
+      />
+
     </div>
   )
 }

--- a/packages/streams/replacer.js
+++ b/packages/streams/replacer.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Teppo Kurki <teppo.kurki@iki.fi>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+const Transform = require('stream').Transform
+const fillTemplate = require('es6-dynamic-template')
+
+require('util').inherits(Replacer, Transform)
+
+function Replacer (options) {
+  Transform.call(this, {
+    objectMode: true
+  })
+  this.doPush = this.push.bind(this)
+  this.regexp = new RegExp(options.regexp, 'gu')
+  this.template = options.template
+}
+
+
+Replacer.prototype._transform = function (chunk, encoding, done) {
+  this.doPush(chunk.toString().replace(this.regexp, this.template))
+  done()
+}
+
+module.exports = Replacer
+
+// const replacers = [
+//   {
+//     regexp: '\u0000',
+//     template: '',
+//     testdata: '\u0000$WIMWV,1\u000047,R,0,N,A21',
+//     testresult: '$WIMWV,147,R,0,N,A21'
+//   }
+//   ,
+//   {
+//     regexp: '^...RMC.*',
+//     template: '',
+//     testdata: '$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A',
+//     testresult: ''
+//   }
+// ]
+
+// replacers.forEach(replacerOptions => {
+//   const replacer = new Replacer(replacerOptions)
+//   replacer.doPush = x => console.log(JSON.stringify(x))
+//   replacer._transform(replacerOptions.testdata, null, () => {})
+// })

--- a/packages/streams/simple.js
+++ b/packages/streams/simple.js
@@ -15,6 +15,7 @@ const Udp = require('./udp')
 const Tcp = require('./tcp')
 const TcpServer = require('./tcpserver')
 const FileStream = require('./filestream')
+const Replacer = require('./replacer')
 const Throttle = require('./throttle')
 const TimestampThrottle = require('./timestamp-throttle')
 const CanboatJs = require('./canboatjs')
@@ -249,17 +250,39 @@ function nmea2000input (subOptions, logging) {
 }
 
 function nmea0183input (subOptions) {
+  let pipePart
   if (subOptions.type === 'tcp') {
-    return [new Tcp(subOptions), new Liner(subOptions)]
+    pipePart = [new Tcp(subOptions), new Liner(subOptions)]
   } else if (subOptions.type === 'tcpserver') {
-    return [new TcpServer(subOptions), new Liner(subOptions)]
+    pipePart = [new TcpServer(subOptions), new Liner(subOptions)]
   } else if (subOptions.type === 'udp') {
-    return [new Udp(subOptions), new SplittingLiner(subOptions)]
+    pipePart = [new Udp(subOptions), new SplittingLiner(subOptions)]
   } else if (subOptions.type === 'serial') {
     const serialport = require('./serialport')
-    return [new serialport(subOptions)]
+    pipePart = [new serialport(subOptions)]
   } else if (subOptions.type === 'gpsd') {
-    return [new gpsd(subOptions)]
+    pipePart = [new gpsd(subOptions)]
+  }
+
+  if (pipePart) {
+    if (subOptions.removeNulls) {
+      pipePart.push(new Replacer({
+        regexp: '\u0000',
+        template: ''
+      }))
+    }
+    if (subOptions.ignoredSentences) {
+      console.log(subOptions.ignoredSentences)
+      subOptions.ignoredSentences.forEach(sentence => {
+        if (sentence.length > 0) {
+          pipePart.push(new Replacer({
+            regexp: `^...${sentence}.*`,
+            template: ''
+          }))
+        }
+      })
+    }
+    return pipePart
   } else {
     throw new Error(`Unknown networking tyoe: ${options.networking}`)
   }


### PR DESCRIPTION
    Add options to ignore null characters from the 0183 input and
    configurable 0183 sentences to remove from the input stream.

![image](https://user-images.githubusercontent.com/1049678/82129842-8c3bae00-97ce-11ea-9ce2-43d6defbcb99.png)

Fixes #970 