### PR TITLE
Fix ws connection query string(iKommunicate) and add self mapping to ws Signal K connections

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -611,19 +611,28 @@ const SignalK = props => {
             props.value.options.type === 'wss') && (
             <FormGroup row>
               <Col xs='0' md='2'>
-                <Label />
+              <Label htmlFor='options.useDiscovery'>Discovery</Label>
               </Col>
-              <Col xs='12' md='3'>
-                <div className='checkbox'>
-                  <Label check htmlFor='enabled'>
+              <Col xs='12' md='10'>
+                <div key={name}>
+                  <Label className='switch switch-text switch-primary'>
                     <Input
                       type='checkbox'
+                      id='options.useDiscovery'
                       name='options.useDiscovery'
+                      className='switch-input'
                       onChange={props.onChange}
                       checked={props.value.options.useDiscovery}
-                    />Use Discovery
+                    />
+                    <span
+                      className='switch-label'
+                      data-on='On'
+                      data-off='Off'
+                    />
+                    <span className='switch-handle' />
                   </Label>
-                </div>
+                  Discover Signal K servers automatically
+                  </div>
               </Col>
             </FormGroup>
           )}

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -424,6 +424,20 @@ class HostInput extends Component {
   }
 }
 
+class RemoteSelfInput extends Component {
+  render () {
+    return (
+      <TextInput
+        title="Remote 'self' to use"
+        name='options.remoteSelf'
+        helpText='like vessels.urn:mrn:signalk:uuid:f6d9f041-4e61-4335-82c0-7a51fb10ae86 OR vessels.urn:mrn:imo:mmsi:230099999'
+        value={this.props.value.remoteSelf}
+        onChange={this.props.onChange}
+      />
+    )
+  }
+}
+
 class Suppress0183Checkbox extends Component {
   constructor (props) {
     super(props)
@@ -667,6 +681,26 @@ const SignalK = props => {
         <PortInput value={props.value.options} onChange={props.onChange} />
       )}
       {serialParams(props)}
+      <FormGroup row>
+        <Col md='2'>
+          <Label htmlFor='options.type'>'self' handling</Label>
+        </Col>
+        <Col xs='12' md='3'>
+          <Input
+            type='select'
+            value={props.value.options.selfHandling || 'noSelf'}
+            name='options.selfHandling'
+            onChange={event => props.onChange(event)}
+          >
+            <option value='useRemoteSelf'>Map remote 'self' to local 'self'</option>
+            <option value='manualSelf'>Manual mapping</option>
+            <option value='noSelf'>No 'self' mapping</option>
+          </Input>
+        </Col>
+      </FormGroup>
+      {props.value.options.selfHandling === 'manualSelf' && (
+        <RemoteSelfInput value={props.value.options} onChange={props.onChange} />
+      )}
     </div>
   )
 }

--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -19,6 +19,7 @@ const Transform = require('stream').Transform
 const SignalK = require('@signalk/client')
 
 const debug = require('debug')('signalk-server:providers:mdns-ws')
+const dataDebug = require('debug')('signalk-server:providers:mdns-ws:data')
 
 const WebSocket = require('ws')
 
@@ -32,6 +33,22 @@ function MdnsWs (options) {
   this.remoteServers = {}
   this.remoteServers[this.selfHost + ':' + this.selfPort] = {}
   const deltaStreamBehaviour = options.subscription ? 'none' : 'all'
+  debug(`deltaStreamBehaviour:${deltaStreamBehaviour}`)
+
+  this.handleContext = () => { }
+  if (options.selfHandling === 'manualSelf') {
+    if (options.remoteSelf) {
+      debug(`Using manual remote self ${options.remoteSelf}`)
+      this.handleContext = (delta) => {
+        if (delta.context === options.remoteSelf) {
+          delete delta.context
+        }
+      }
+    } else {
+      console.error('Manual self handling speficied but no remoteSelf configured')
+    }
+  }
+
   if (options.ignoreServers) {
     options.ignoreServers.forEach(s => {
       this.remoteServers[s] = {}
@@ -106,6 +123,19 @@ MdnsWs.prototype.connect = function (client) {
     .connect()
     .then(() => {
       setProviderStatus(that, providerId, `ws connection connected to ${client.options.hostname}:${client.options.port}`)
+      if (this.options.selfHandling === 'useRemoteSelf') {
+        client.API().then(api => api.get('/self')).then(selfFromServer => {
+          debug(`Mapping context ${selfFromServer} to self (empty context)`)
+          this.handleContext = (delta) => {
+            if (delta.context === selfFromServer) {
+              delete delta.context
+            }
+          }
+        }).catch(err => {
+          console.error('Error retrieving self from remote server')
+          console.error(err)
+        })
+      }
       that.remoteServers[client.options.hostname + ':' + client.options.port] = client
       if ( that.options.subscription ) {
         let parsed 
@@ -129,6 +159,8 @@ MdnsWs.prototype.connect = function (client) {
   
   client.on('delta', (data) => {
     if (data && data.updates) {
+      that.handleContext(data)
+      if (dataDebug.enabled) { dataDebug(JSON.stringify(data)) }
       data.updates.forEach(function (update) {
         update['$source'] = providerId
       })

--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -31,6 +31,7 @@ function MdnsWs (options) {
   this.selfPort = options.app.config.getExternalPort()
   this.remoteServers = {}
   this.remoteServers[this.selfHost + ':' + this.selfPort] = {}
+  const deltaStreamBehaviour = options.subscription ? 'none' : 'all'
   if (options.ignoreServers) {
     options.ignoreServers.forEach(s => {
       this.remoteServers[s] = {}
@@ -43,6 +44,7 @@ function MdnsWs (options) {
       useTLS: options.protocol === 'wss',
       reconnect: true,
       autoConnect: false,
+      deltaStreamBehaviour
     })
     this.connect(this.signalkClient)
   } else {
@@ -69,7 +71,8 @@ function MdnsWs (options) {
             client = server.createClient({
               useTLS: false,
               reconnect: true,
-              autoConnect: false
+              autoConnect: false,
+              deltaStreamBehaviour
             })
             this.connect(client)
           }
@@ -118,9 +121,6 @@ MdnsWs.prototype.connect = function (client) {
           debug('sending subscription %j', sub)
           client.subscribe(sub, String(idx))
         })
-      } else {
-        debug('subscribing to all')
-        client.subscribe()
       }
     })
     .catch(err => {

--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -41,7 +41,7 @@ function MdnsWs (options) {
     this.signalkClient = new SignalK.Client({
       hostname: options.host,
       port: options.port,
-      useTLS: options.protocol === 'wss',
+      useTLS: options.type === 'wss',
       reconnect: true,
       autoConnect: false,
       deltaStreamBehaviour

--- a/packages/streams/package.json
+++ b/packages/streams/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/SignalK/signalk-server-node#readme",
   "dependencies": {
     "@canboat/canboatjs": "^1.4.0",
-    "@signalk/client": "^2.0.4",
+    "@signalk/client": "^2.1.0",
     "@signalk/n2k-signalk": "^1.2.1",
     "@signalk/nmea0183-signalk": "^3.0.0",
     "@signalk/signalk-schema": "^1.3.1",

--- a/packages/streams/simple.js
+++ b/packages/streams/simple.js
@@ -277,19 +277,8 @@ function fileInput (subOptions) {
 
 function signalKInput (subOptions) {
   if (subOptions.type === 'ws' || subOptions.type === 'wss') {
-    const options = {
-      app: subOptions.app,
-      providerId: subOptions.providerId,
-      ignoreServers: subOptions.ignoreServers,
-      subscription: subOptions.subscription
-    }
-    if (!subOptions.useDiscovery) {
-      options.host = subOptions.host
-      options.port = subOptions.port
-    }
-    options.protocol = subOptions.type
     const mdns_ws = require('./mdns-ws')
-    return [new mdns_ws(options)]
+    return [new mdns_ws(subOptions)]
   } else if (subOptions.type === 'tcp') {
     return [new Tcp(subOptions), new Liner(subOptions)]
   } else if (subOptions.type === 'udp') {


### PR DESCRIPTION
Update to using SignalK js client ^2.1.0 and add needed changes so that the server can connect to SK servers without subscriptions support, using query parameter `all`.

Add the option to map the remote SK server's self to local `self`, either automatically by getting the remote server's self via http api or explicitly configuring the remote self id manually.

The mapping removes the context from the incoming self deltas, allowing the server to treat them like they were coming from a local provider.
