### PR TITLE
chore: remove request-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,8 +139,6 @@
     "lint-staged": "^10.0.3",
     "mocha": "^7.0.1",
     "prettier": "^1.18.2",
-    "request": "^2.88.0",
-    "request-promise": "^4.2.5",
     "rimraf": "^3.0.2",
     "tslint": "^5.20.0",
     "tslint-config-prettier": "^1.18.0",

--- a/test/deltacache.js
+++ b/test/deltacache.js
@@ -5,9 +5,7 @@ chai.use(require('@signalk/signalk-schema').chaiModule)
 const _ = require('lodash')
 const assert = require('assert')
 const freeport = require('freeport-promise')
-const WebSocket = require('ws')
-const rp = require('request-promise')
-const startServerP = require('./servertestutilities').startServerP
+const { startServerP, sendDelta } = require('./servertestutilities')
 
 const testDelta = {
   context: 'vessels.self',
@@ -71,10 +69,6 @@ const expectedOrder = [
 describe('deltacache', () => {
   let serverP, port, deltaUrl, deltaP
 
-  function sendDelta (delta) {
-    return rp({ url: deltaUrl, method: 'POST', json: delta })
-  }
-
   before(() => {
     serverP = freeport().then(p => {
       port = p
@@ -82,7 +76,7 @@ describe('deltacache', () => {
       return startServerP(p)
     })
     deltaP = serverP.then(() => {
-      return sendDelta(testDelta)
+      return sendDelta(testDelta, deltaUrl)
     })
   })
 

--- a/test/metadata.js
+++ b/test/metadata.js
@@ -1,8 +1,7 @@
 const _ = require('lodash')
 const assert = require('assert')
 const freeport = require('freeport-promise')
-const WebSocket = require('ws')
-const rp = require('request-promise')
+const fetch = require('node-fetch')
 const startServerP = require('./servertestutilities').startServerP
 
 const metaConfig = {
@@ -49,7 +48,7 @@ describe('Metadata retrieval', () => {
   it('valid .../meta works', () => {
     return getUrl(
       `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrue/meta`
-    ).then(result => {
+    ).then(r => r.json()).then(result => {
       assert.equal(result.units, 'rad')
     })
   })
@@ -57,8 +56,8 @@ describe('Metadata retrieval', () => {
   it('invalid .../meta returns error', done => {
     getUrl(
       `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrueTRUE/meta`
-    ).catch(reason => {
-      assert.equal(reason.statusCode, 404)
+    ).then(response => {
+      assert.equal(response.status, 404)
       done()
     })
   })
@@ -66,7 +65,7 @@ describe('Metadata retrieval', () => {
   it('valid .../units works', () => {
     return getUrl(
       `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrue/meta/units`
-    ).then(result => {
+    ).then(r => r.json()).then(result => {
       assert.equal(result, 'rad')
     })
   })
@@ -74,8 +73,8 @@ describe('Metadata retrieval', () => {
   it('invalid .../units returns error', done => {
     getUrl(
       `http://localhost:${port}/signalk/v1/api/vessels/foo/navigation/headingTrueTRUE/meta/units`
-    ).catch(reason => {
-      assert.equal(reason.statusCode, 404)
+    ).then(response => {
+      assert.equal(response.status, 404)
       done()
     })
   })
@@ -83,7 +82,7 @@ describe('Metadata retrieval', () => {
   it('valid .../from defaults works', () => {
     return getUrl(
       `http://localhost:${port}/signalk/v1/api/vessels/self/electrical/batteries/1/voltage/meta/testKey`
-    ).then(result => {
+    ).then(r => r.json()).then(result => {
       assert.equal(result, 'testValue')
     })
   })
@@ -91,18 +90,12 @@ describe('Metadata retrieval', () => {
   it('valid .../units with defaults works', () => {
     return getUrl(
       `http://localhost:${port}/signalk/v1/api/vessels/self/electrical/batteries/1/voltage/meta/units`
-    ).then(result => {
+    ).then(r => r.json()).then(result => {
       assert.equal(result, 'V')
     })
   })
 
-  function getUrl (url) {
-    return serverP.then(_ => {
-      return rp({
-        url: url,
-        method: 'GET',
-        json: true
-      })
-    })
+  function getUrl(url) {
+    return serverP.then(_ => fetch(url))
   }
 })

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -2,7 +2,6 @@ const assert = require('assert')
 
 const fetch = require('node-fetch')
 const freeport = require('freeport-promise')
-const rp = require('request-promise')
 const Server = require('../lib/')
 const fs = require('fs')
 const path = require('path')

--- a/test/servertestutilities.js
+++ b/test/servertestutilities.js
@@ -80,6 +80,10 @@ const ADMIN_USER_PASSWORD = 'admin'
 
 module.exports = {
   WsPromiser: WsPromiser,
+  sendDelta: (delta, deltaUrl) => {
+    if(!deltaUrl) console.trace()
+    return fetch(deltaUrl, { method: 'POST', body: JSON.stringify(delta), headers: { 'Content-Type': 'application/json' } })
+  },
   startServerP: function startServerP (port, enableSecurity, extraConfig={}, securityConfig) {
     const Server = require('../lib')
     const props = {

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -1,8 +1,7 @@
 const _ = require('lodash')
 const assert = require('assert')
+const {sendDelta} = require('./servertestutilities')
 const freeport = require('freeport-promise')
-const WebSocket = require('ws')
-const rp = require('request-promise')
 const { startServerP, WsPromiser } = require('./servertestutilities')
 
 function getDelta (overwrite) {
@@ -176,10 +175,6 @@ describe('Subscriptions', _ => {
       })
   })
 
-  function sendDelta (delta) {
-    return rp({ url: deltaUrl, method: 'POST', json: delta })
-  }
-
   it('?subscribe=self subscription serves self data', function () {
     let self, wsPromiser
 
@@ -198,7 +193,8 @@ describe('Subscriptions', _ => {
           sendDelta(
             getDelta({
               context: self
-            })
+            }),
+            deltaUrl
           )
         ])
       })
@@ -212,7 +208,7 @@ describe('Subscriptions', _ => {
 
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getDelta({ context: 'vessels.othervessel' }))
+          sendDelta(getDelta({ context: 'vessels.othervessel' }), deltaUrl)
         ])
       })
       .then(results => {
@@ -238,7 +234,8 @@ describe('Subscriptions', _ => {
           sendDelta(
             getDelta({
               context: self
-            })
+            }),
+            deltaUrl
           )
         ])
       })
@@ -247,7 +244,7 @@ describe('Subscriptions', _ => {
 
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getDelta({ context: 'vessels.othervessel' }))
+          sendDelta(getDelta({ context: 'vessels.othervessel' }), deltaUrl)
         ])
       })
       .then(results => {
@@ -273,7 +270,8 @@ describe('Subscriptions', _ => {
           sendDelta(
             getDelta({
               context: self
-            })
+            }),
+            deltaUrl
           )
         ])
       })
@@ -282,7 +280,7 @@ describe('Subscriptions', _ => {
 
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getDelta({ context: 'vessels.othervessel' }))
+          sendDelta(getDelta({ context: 'vessels.othervessel' }), deltaUrl)
         ])
       })
       .then(results => {
@@ -311,7 +309,8 @@ describe('Subscriptions', _ => {
           sendDelta(
             getDelta({
               context: self
-            })
+            }),
+            deltaUrl
           )
         ])
       })
@@ -320,7 +319,7 @@ describe('Subscriptions', _ => {
 
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getDelta({ context: 'vessels.othervessel' }))
+          sendDelta(getDelta({ context: 'vessels.othervessel' }), deltaUrl)
         ])
       })
       .then(results => {
@@ -359,7 +358,8 @@ describe('Subscriptions', _ => {
           sendDelta(
             getDelta({
               context: self
-            })
+            }),
+            deltaUrl
           )
         ])
       })
@@ -376,7 +376,7 @@ describe('Subscriptions', _ => {
 
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getDelta({ context: 'vessels.othervessel' }))
+          sendDelta(getDelta({ context: 'vessels.othervessel' }), deltaUrl)
         ])
       })
       .then(results => {
@@ -419,7 +419,8 @@ describe('Subscriptions', _ => {
           sendDelta(
             getNameDelta({
               context: 'vessels.' + self
-            })
+            }),
+            deltaUrl
           )
         ])
       })
@@ -445,7 +446,7 @@ describe('Subscriptions', _ => {
 
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getNameDelta({ context: 'vessels.othervessel' }))
+          sendDelta(getNameDelta({ context: 'vessels.othervessel' }), deltaUrl)
         ])
       })
       .then(results => {
@@ -488,13 +489,13 @@ describe('Subscriptions', _ => {
       .then(results => {
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getClosePosistionDelta())
+          sendDelta(getClosePosistionDelta(), deltaUrl)
         ])
       })
       .then(results => {
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getClosePosistionDelta())
+          sendDelta(getClosePosistionDelta(), deltaUrl)
         ])
       })
       .then(results => {
@@ -504,12 +505,12 @@ describe('Subscriptions', _ => {
         assert(delta.updates[0].values.length === 1, 'Receives just one value')
         assert(delta.context === 'vessels.closeVessel')
 
-        return sendDelta(getFarPosistionDelta())
+        return sendDelta(getFarPosistionDelta(), deltaUrl)
       })
       .then(results => {
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getFarPosistionDelta())
+          sendDelta(getFarPosistionDelta(), deltaUrl)
         ])
       })
       .then(results => {
@@ -548,13 +549,13 @@ it('relativePosition subscription works with null positions', function () {
     .then(results => {
       return Promise.all([
         wsPromiser.nextMsg(),
-        sendDelta(getNullPositionDelta())
+        sendDelta(getNullPositionDelta(), deltaUrl)
       ])
     })
       .then(results => {
         return Promise.all([
           wsPromiser.nextMsg(),
-          sendDelta(getNullPositionDelta())
+          sendDelta(getNullPositionDelta(), deltaUrl)
         ])
       })
     .then(results => {
@@ -582,7 +583,8 @@ it('relativePosition subscription works with null positions', function () {
           sendDelta(
             getDelta({
               context: self
-            })
+            }),
+            deltaUrl
           )
         ])
       })


### PR DESCRIPTION
request-promise was only used in tests and can be easily replaced
with the more familiar fetch.