### PR TITLE
feature: reorganise and rename admin components

### DIFF
--- a/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
+++ b/packages/server-admin-ui/src/components/Sidebar/Sidebar.js
@@ -204,11 +204,6 @@ const mapStateToProps = state => {
         name: 'Data Browser',
         url: '/databrowser',
         icon: 'icon-folder'
-      },
-      {
-        name: 'Playground',
-        url: '/playground',
-        icon: 'icon-control-play'
       }
     ]
   }
@@ -249,20 +244,12 @@ const mapStateToProps = state => {
             url: '/serverConfiguration/settings'
           },
           {
-            name: 'Vessel data',
-            url: '/serverConfiguration/vessel'
-          },
-          {
-            name: 'Plugin Config',
-            url: '/serverConfiguration/plugins/-'
-          },
-          {
             name: 'Connections',
             url: '/serverConfiguration/connections/-'
           },
           {
-            name: 'Data log files',
-            url: '/serverConfiguration/datalogs'
+            name: 'Plugin Config',
+            url: '/serverConfiguration/plugins/-'
           },
           {
             name: 'Server Log',
@@ -272,6 +259,10 @@ const mapStateToProps = state => {
             name: 'Update',
             url: '/serverConfiguration/update',
             badge: serverUpdateBadge
+          },
+          {
+            name: 'Data Fiddler',
+            url: '/serverConfiguration/datafiddler'
           }
         ]
       }

--- a/packages/server-admin-ui/src/containers/Full/Full.js
+++ b/packages/server-admin-ui/src/containers/Full/Full.js
@@ -67,8 +67,8 @@ class Full extends Component {
                   component={loginOrOriginal(DataBrowser, true)}
                  />
                 <Route
-                  path='/playground'
-                  name='Playground'
+                  path='/serverConfiguration/datafiddler'
+                  name='DataFiddler'
                   component={loginOrOriginal(Playground, true)}
                 />
                 <Route
@@ -84,16 +84,8 @@ class Full extends Component {
                   component={loginOrOriginal(Settings)}
                 />
                 <Route
-                  path='/serverConfiguration/vessel'
-                  component={loginOrOriginal(VesselConfiguration)}
-                />
-                <Route
                   path='/serverConfiguration/connections/:providerId'
                   component={loginOrOriginal(ProvidersConfiguration)}
-                />
-                <Route
-                  path='/serverConfiguration/datalogs'
-                  component={loginOrOriginal(Logging)}
                 />
                 <Route
                   path='/serverConfiguration/log'

--- a/packages/server-admin-ui/src/views/ServerConfig/Settings.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/Settings.js
@@ -18,6 +18,9 @@ import {
   Table
 } from 'reactstrap'
 
+import VesselConfiguration from './VesselConfiguration'
+import LogFiles from './Logging'
+
 function fetchSettings () {
   fetch(`/settings`, {
     credentials: 'include'
@@ -28,7 +31,7 @@ function fetchSettings () {
     })
 }
 
-class Settings extends Component {
+class ServerSettings extends Component {
   constructor (props) {
     super(props)
     this.state = {
@@ -93,6 +96,9 @@ class Settings extends Component {
       this.state.hasData && (
         <div className='animated fadeIn'>
           <Card>
+            <CardHeader>
+              <i className='fa fa-align-justify' /><strong>Server Settings</strong>
+            </CardHeader>
             <CardBody>
               <Form
                 action=''
@@ -218,6 +224,24 @@ class Settings extends Component {
                 </FormGroup>
                 <FormGroup row>
                   <Col md='2'>
+                    <Label htmlFor='pruneContextsMinutes'>
+                    Maximum age of inactive vessels' data
+                    </Label>
+                  </Col>
+                  <Col xs='12' md={fieldColWidthMd}>
+                    <Input
+                      type='text'
+                      name='pruneContextsMinutes'
+                      onChange={this.handleChange}
+                      value={this.state.pruneContextsMinutes}
+                    />
+                     <FormText color='muted'>
+                      Vessels that have not been updated after this many minutes will be removed
+                    </FormText>
+                  </Col>
+                </FormGroup>
+                <FormGroup row>
+                  <Col md='2'>
                     <Label htmlFor='loggingDirectory'>
                       Data Logging Directory
                     </Label>
@@ -235,25 +259,6 @@ class Settings extends Component {
                     </FormText>
                   </Col>
               </FormGroup>
-              <FormGroup row>
-                  <Col md='2'>
-                    <Label htmlFor='pruneContextsMinutes'>
-                    Maximum age of inactive vessels' data
-                    </Label>
-                  </Col>
-                  <Col xs='12' md={fieldColWidthMd}>
-                    <Input
-                      type='text'
-                      name='pruneContextsMinutes'
-                      onChange={this.handleChange}
-                      value={this.state.pruneContextsMinutes}
-                    />
-                     <FormText color='muted'>
-                      
-                      Vessels that have not been updated after this many minutes will be removed
-                    </FormText>
-                  </Col>
-                </FormGroup>
               </Form>
             </CardBody>
             <CardFooter>
@@ -275,4 +280,16 @@ class Settings extends Component {
   }
 }
 
-export default connect()(Settings)
+const ReduxedSettings = connect()(ServerSettings)
+
+class Settings extends Component {
+  render() {
+    return <div>
+      <VesselConfiguration/>
+      <ReduxedSettings/>
+      <LogFiles/>
+      </div>
+  }
+}
+
+export default Settings

--- a/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/VesselConfiguration.js
@@ -72,6 +72,9 @@ class VesselConfiguration extends Component {
       this.state.hasData && (
         <div className='animated fadeIn'>
           <Card>
+            <CardHeader>
+              <i className='fa fa-align-justify' /><strong>Vessel Base Data</strong>
+            </CardHeader>
             <CardBody>
               <Form
                 action=''


### PR DESCRIPTION
Reduce the number of items under admin menu 'Server' by grouping
server settings, vessel configuration and data log panels
on a single page.

Rename Playground to Data Fiddler to better(?) reflect what it is:
a place where you can fiddle with (input) data.