### PR TITLE
feature: add custom logo

### DIFF
--- a/src/interfaces/webapps.js
+++ b/src/interfaces/webapps.js
@@ -33,6 +33,11 @@ module.exports = function(app) {
 
 function mountWebapps(app) {
   debug('MountWebApps')
+  const logopath = path.resolve(app.config.configPath, 'logo.svg')
+  if(fs.existsSync(logopath)) {
+    debug(`Found custom logo at ${logopath}, adding route for it`)
+    app.use('/admin/fonts/signal-k-logo-image-text.*', (req, res) => res.sendFile(logopath))
+  }
   modulesWithKeyword(app, 'signalk-webapp').forEach(moduleData => {
     let webappPath = path.join(moduleData.location, moduleData.module)
     if (fs.existsSync(webappPath + '/public/')) {


### PR DESCRIPTION
The user can replace the logo at the top left of the admin
app by placing an svg file named 'logo.svg' in the settings
directory.