### PR TITLE
feature: improve plugin config form layout

### DIFF
--- a/packages/server-admin-ui/scss/_custom.scss
+++ b/packages/server-admin-ui/scss/_custom.scss
@@ -1,1 +1,21 @@
 // Here you can add other styles
+
+
+form.rjsf  label {
+  margin-bottom: 0;
+}
+
+form.rjsf  div>p.field-description {
+  font-size: 0.7rem;
+  font-style: italic;
+  margin-bottom: 0px;
+}
+
+form.rjsf input {
+  width: auto;
+}
+
+form.rjsf div.row.array-item {
+  background-color: aliceblue;
+  margin-bottom: 3px;
+}

--- a/packages/server-admin-ui/src/views/Configuration/Configuration.js
+++ b/packages/server-admin-ui/src/views/Configuration/Configuration.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import ReactDOM from 'react-dom'
 import { connect } from 'react-redux'
 import PluginConfigurationForm from './../ServerConfig/PluginConfigurationForm'
-import {Button, Card, CardBody, CardHeader, Collapse} from 'reactstrap'
+import {Container, Card, CardBody, CardHeader, Collapse} from 'reactstrap'
 
 class Dashboard extends Component {
   constructor(props) {
@@ -41,7 +41,7 @@ class Dashboard extends Component {
 
   render () {
     return (
-      <div>
+      <Container>
         {this.state.plugins.map((plugin, i) => {
           const isOpen = this.props.match.params.pluginid === plugin.id
           return (
@@ -52,7 +52,7 @@ class Dashboard extends Component {
               toggleForm={this.toggleForm.bind(this, i, plugin.id)}
               saveData={saveData.bind(null, plugin.id)}/>
         )})}
-      </div>
+      </Container>
     )
   }
 }


### PR DESCRIPTION
- limit the card width as the form content is pretty columnar
- do not force inputs to be 100%
- less emphasis on field descriptions
- less vertical margins, more compact
- make array items more distinctive with a background

Previously:

![image](https://user-images.githubusercontent.com/1049678/83337726-66ca9c00-a2c6-11ea-81be-5416d138bfa4.png)

Improved:
![image](https://user-images.githubusercontent.com/1049678/83337752-9083c300-a2c6-11ea-835e-87da9a1e35d3.png)
