### PR TITLE
feature: add stdout sending to TCP Client connections

### DIFF
--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -634,6 +634,7 @@ const NMEA0183 = props => {
         <div>
           <HostInput value={props.value.options} onChange={props.onChange} />
           <PortInput value={props.value.options} onChange={props.onChange} />
+          <StdOutInput value={props.value.options} onChange={props.onChange} />
         </div>
       )}
       {props.value.options.type === 'tcpserver' && (


### PR DESCRIPTION
Add sending to defined stdout events to TCP connection.
As similar option is available in the serial connection

Fixes #1054

Signed-off-by: Marcel Verpaalen <marcel@verpaalen.com>