### PR TITLE
chore: add dependabot

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check the npm registry for updates every day (weekdays)
+    schedule:
+      interval: "daily"
+
+  # Enable version updates for Docker
+  - package-ecosystem: "docker"
+    # Look for a `Dockerfile` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Greenkeeper went out, let's see how Github's dependabot
does.

https://help.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates