### PR TITLE
feature: add support for retrieving the zones metadata through the REST API.

### DIFF
--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -48,22 +48,27 @@ module.exports = function(app) {
           let meta = getMetadata(path.slice(0, path.length - 1).join('.'))
           let fromDefaults = _.get(app.deltaCache.defaults, path.join('.'))
 
-          const metaData = {...meta, ...fromDefaults};
-          console.log(metaData)
-          if (!metaData.zones) {
-            metaData.zones = [];
-          }
+          if (meta || fromDefaults) {
+            const metaData = {...meta, ...fromDefaults};
+            if (!metaData.zones) {
+              metaData.zones = [];
+            }
 
-          res.json(metaData);
-          return
+            res.json(metaData);
+            return
+          }
         }
         if (path.length > 5 && path.join(".").endsWith("meta.units")) {
           let units = _.get(app.deltaCache.defaults, path.join('.'))
-            || getUnits(path.slice(0, path.length - 2).join('.'))
-
-          res.json(units)
-          return
+          if (!units) {
+            units = getUnits(path.slice(0, path.length - 2).join('.'))
+          }
+          if (units) {
+            res.json(units)
+            return
+          }
         }
+
         if (path.length > 5 && path.join(".").endsWith("meta.zones")) {
           let zones = _.get(app.deltaCache.defaults, path.join('.')) || [];
           res.json(zones)

--- a/src/interfaces/rest.js
+++ b/src/interfaces/rest.js
@@ -44,27 +44,30 @@ module.exports = function(app) {
 
         path = path.length > 0 ? path.replace(/\/$/, '').split('/') : []
 
-        if (path.length > 4 && path[path.length - 1] === 'meta') {
+        if (path.length > 4 && path.join(".").endsWith("meta")) {
           let meta = getMetadata(path.slice(0, path.length - 1).join('.'))
           let fromDefaults = _.get(app.deltaCache.defaults, path.join('.'))
-          if (meta || fromDefaults) {
-            res.json({ ...meta, ...fromDefaults })
-            return
+
+          const metaData = {...meta, ...fromDefaults};
+          console.log(metaData)
+          if (!metaData.zones) {
+            metaData.zones = [];
           }
+
+          res.json(metaData);
+          return
         }
-        if (
-          path.length > 5 &&
-          path[path.length - 1] === 'units' &&
-          path[path.length - 2] === 'meta'
-        ) {
+        if (path.length > 5 && path.join(".").endsWith("meta.units")) {
           let units = _.get(app.deltaCache.defaults, path.join('.'))
-          if (!units) {
-            units = getUnits(path.slice(0, path.length - 2).join('.'))
-          }
-          if (units) {
-            res.json(units)
-            return
-          }
+            || getUnits(path.slice(0, path.length - 2).join('.'))
+
+          res.json(units)
+          return
+        }
+        if (path.length > 5 && path.join(".").endsWith("meta.zones")) {
+          let zones = _.get(app.deltaCache.defaults, path.join('.')) || [];
+          res.json(zones)
+          return
         }
 
         path = path.map(p => (p === 'self' ? app.selfId : p))


### PR DESCRIPTION
Add support for HTTP requests ending in .../meta/zones. Update .../meta to include the zones as well.
As per the spec, if no zones are defined for a requested path, the zones key will have a value of [].
After the change, the zones for all the paths can be defined in defaults.json according to the [SignalK data model](http://signalk.org/specification/1.0.0/doc/data_model.html).

Motivation for implementing the spec comes from an increased need of centralized alarm zone management – managing them is comparatively easier on the server-side.