### PR TITLE
chore: harmonise debug names

### DIFF
--- a/packages/streams/canboatjs.js
+++ b/packages/streams/canboatjs.js
@@ -16,7 +16,7 @@
 
 const Transform = require('stream').Transform
 const FromPgn = require('@canboat/canboatjs').FromPgn
-const debug = require('debug')('signalk:canbusjs')
+const debug = require('debug')('signalk:streams:canboatjs')
 const _ = require('lodash')
 
 function CanboatJs (options) {

--- a/packages/streams/execute.js
+++ b/packages/streams/execute.js
@@ -37,7 +37,7 @@
  */
 
 const Transform = require('stream').Transform
-const debug = require('debug')('signalk:executor')
+const debug = require('debug')('signalk:streams:execute')
 
 function Execute (options) {
   Transform.call(this, {})

--- a/packages/streams/gpsd.js
+++ b/packages/streams/gpsd.js
@@ -32,7 +32,7 @@
 
 const Transform = require('stream').Transform
 const gpsd = require('node-gpsd')
-const debug = require('debug')('signalk:provider:gpsd')
+const debug = require('debug')('signalk:streams:gpsd')
 
 function Gpsd (options) {
   Transform.call(this, {

--- a/packages/streams/keys-filter.js
+++ b/packages/streams/keys-filter.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Transform = require('stream').Transform
-const debug = require('debug')('signalk-server-node/providers/keys-filter')
+const debug = require('debug')('signalk:streams:keys-filter')
 
 function ToSignalK (options) {
   Transform.call(this, {

--- a/packages/streams/logging.js
+++ b/packages/streams/logging.js
@@ -16,7 +16,7 @@
 
 const { FileTimestampStream } = require('file-timestamp-stream')
 const path = require('path')
-const debug = require('debug')('signalk:logging')
+const debug = require('debug')('signalk:streams:logging')
 const fs = require('fs')
 
 const filenamePattern = /skserver\-raw\_\d\d\d\d\-\d\d\-\d\dT\d\d\.log/

--- a/packages/streams/mdns-ws.js
+++ b/packages/streams/mdns-ws.js
@@ -18,8 +18,8 @@ const Transform = require('stream').Transform
 
 const SignalK = require('@signalk/client')
 
-const debug = require('debug')('signalk-server:providers:mdns-ws')
-const dataDebug = require('debug')('signalk-server:providers:mdns-ws:data')
+const debug = require('debug')('signalk:streams:mdns-ws')
+const dataDebug = require('debug')('signalk:streams:mdns-ws-data')
 
 const WebSocket = require('ws')
 

--- a/packages/streams/n2kAnalyzer.js
+++ b/packages/streams/n2kAnalyzer.js
@@ -15,7 +15,7 @@
  */
 
 const Transform = require('stream').Transform
-const debug = require('debug')('signalk:n2kAnalyzer')
+const debug = require('debug')('signalk:streams:n2k-analyzer')
 
 function N2KAnalyzer (options) {
   Transform.call(this, {

--- a/packages/streams/nmea0183-signalk.js
+++ b/packages/streams/nmea0183-signalk.js
@@ -32,7 +32,7 @@
 const Transform = require('stream').Transform
 const Parser = require('@signalk/nmea0183-signalk')
 const utils = require('@signalk/nmea0183-utilities')
-const debug = require('debug')('signalk-server-node/providers/nmea0183-signalk')
+const debug = require('debug')('signalk:streams:nmea0183-signalk')
 const n2kToDelta = require('@signalk/n2k-signalk').toDelta
 const FromPgn = require('@canboat/canboatjs').FromPgn
 

--- a/packages/streams/s3.js
+++ b/packages/streams/s3.js
@@ -16,7 +16,7 @@
 
 var Transform = require('stream').Transform
 const AWS = require('aws-sdk')
-const debug = require('debug')('signalk-server:s3-provider')
+const debug = require('debug')('signalk:streams:s3-provider')
 
 function S3Provider ({ bucket, prefix }) {
   Transform.call(this, {

--- a/packages/streams/serialport.js
+++ b/packages/streams/serialport.js
@@ -62,7 +62,7 @@ const child_process = require('child_process')
 const shellescape = require('any-shell-escape')
 const SerialPort = require('serialport')
 const isArray = require('lodash').isArray
-const debug = require('debug')('signalk:serialport')
+const debug = require('debug')('signalk:streams:serialport')
 
 function SerialStream (options) {
   if (!(this instanceof SerialStream)) {

--- a/packages/streams/tcp.js
+++ b/packages/streams/tcp.js
@@ -32,8 +32,8 @@ const net = require('net')
 const Transform = require('stream').Transform
 const isArray = require('lodash').isArray
 
-const debug = require('debug')('signalk-provider-tcp')
-const debugData = require('debug')('signalk-provider-tcp.data')
+const debug = require('debug')('signalk-server:streams:tcp')
+const debugData = require('debug')('signalk-server:streams:tcp-data')
 
 function TcpStream (options) {
   Transform.call(this, options)

--- a/packages/streams/udp.js
+++ b/packages/streams/udp.js
@@ -34,7 +34,7 @@
  */
 
 const Transform = require('stream').Transform
-const debug = require('debug')('signalk-server:udp-provider')
+const debug = require('debug')('signalk:streams:udp')
 
 function Udp (options) {
   Transform.call(this, {

--- a/src/interfaces/nmea-tcp.js
+++ b/src/interfaces/nmea-tcp.js
@@ -24,7 +24,7 @@ module.exports = function(app) {
   const port = process.env.NMEA0183PORT || 10110
   const api = {}
 
-  const debug = require('debug')('signalk-server:interfaces:tcp')
+  const debug = require('debug')('signalk-server:interfaces:tcp:nmea0183')
   api.start = function() {
     debug('Starting tcp interface')
 

--- a/src/interfaces/tcp.ts
+++ b/src/interfaces/tcp.ts
@@ -17,7 +17,7 @@ import Debug from 'debug'
 import { values } from 'lodash'
 import { createServer, Server, Socket } from 'net'
 import split from 'split'
-const debug = Debug('signalk-server:interfaces:tcpstream')
+const debug = Debug('signalk-server:interfaces:tcp:signalk')
 import { Interface, SignalKServer, Unsubscribes } from '../types'
 
 interface SocketWithId extends Socket {

--- a/src/mdns.js
+++ b/src/mdns.js
@@ -17,7 +17,7 @@
 'use strict'
 
 const _ = require('lodash')
-const debug = require('debug')('signalk-server:interfaces:mdns')
+const debug = require('debug')('signalk-server:mdns')
 const dnssd = require('dnssd2')
 const ports = require('./ports')
 

--- a/src/security.js
+++ b/src/security.js
@@ -18,7 +18,7 @@ const fs = require('fs')
 const path = require('path')
 const Mode = require('stat-mode')
 const pem = require('pem')
-const debug = require('debug')('signalk-server')
+const debug = require('debug')('signalk-server:security')
 const _ = require('lodash')
 const dummysecurity = require('./dummysecurity')
 

--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const debug = require('debug')('sk-simple-token-security')
+const debug = require('debug')('signalk-server:tokensecurity')
 const util = require('util')
 const jwt = require('jsonwebtoken')
 const _ = require('lodash')


### PR DESCRIPTION
Main server code uses signalk-server prefix, streams
signalk:streams prefix as it can be used outside the server
context.

Partial fix for #1031.