### PR TITLE
feature: add seatalk connection type

### DIFF
--- a/Seatalk(GPIO).md
+++ b/Seatalk(GPIO).md
@@ -1,0 +1,50 @@
+## Seatalk(GPIO)
+
+### 1. Intro
+
+The connection with ”Input type” => ”Seatalk(GPIO)” supports the function to receive, via simple DIY hardware and one of the GPIO:s on the Raspberry, Raymarine Seatalk 1(ST1) data and convert it to SignalK delta. This information can then be forwarded to a NMEA 0183 or NMEA 2000 network with appropriate hardware and plugins. A guide to SeaTalk is found [here](http://boatprojects.blogspot.com/2012/12/beginners-guide-to-raymarines-seatalk.html)
+
+Original idea is picked from https://github.com/Thomas-GeDaD/Seatalk1-Raspi-reader
+
+### 2. Hardware
+
+![ST1_opto_SK](https://user-images.githubusercontent.com/16189982/86477381-99920500-bd48-11ea-828d-75459a93d0c5.jpeg)
+
+The circuit is referring to [this optocoupler](https://www.amazon.com/ARCELI-Optocoupler-Isolation-Converter-Photoelectric/dp/B07M78S8LB/ref=sr_1_2?dchild=1&keywords=pc817+optocoupler&qid=1593516071&sr=8-2) but a similar product can of course be used. The LED in the circuit will flicker when there is ST1 traffic. 
+
+Choosing an optocoupler as the hardware interface is a smart way to avoid ground loops and electrical isolation from hazardous voltages.
+
+### 3. Software
+
+Due the DYI approach and that this function have limited users You have, before configuring the actual connection, to install some software manually in a terminal window.
+Start with an update and then the software install
+
+    $ sudo apt-get update && sudo apt-get install pigpio python-pigpio python3-pigpio
+
+The connection relies on a [daemon](http://abyz.me.uk/rpi/pigpio/) which is enabled and started via a systemd service. Install with
+
+    $ sudo systemctl enable pigpiod && sudo systemctl restart  pigpiod
+
+Could be checked with 
+
+    $ sudo systemctl status pigpiod
+
+Now go on add a connection, in the admin GUI, with type ”Seatalk(GPIO)” according to the picture. 
+
+![ST1_connection_SK](https://user-images.githubusercontent.com/16189982/86477500-d78f2900-bd48-11ea-87f6-875950c462ef.png)
+
+Select which pin, one of the green ones in the picture below, You have shoosen as input and use ”Invert signal” "YES" if You are using the hardware setup above. Invert "NO" is used if You have a different hardware interface which is not inverting the input signal.
+
+![GPIO](https://user-images.githubusercontent.com/16189982/86477812-8469a600-bd49-11ea-8e55-4ee4400a2c17.png)
+
+Restart the SignalK server and then use the ”Data Browser” in the admin GUI to confirm that You are receiving the SK data
+ 
+If You are in doubt, if there is data available at the selected GPIO, You can download a program
+
+    $ wget https://raw.githubusercontent.com/MatsA/seatalk1-to-NMEA0183/master/STALK_read.py
+    
+change the setup in the beginning of program and execute it with 
+
+    $ sudo python STALK_read.py
+    
+If You succed You will se the ST1 sentences roll in.

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -47,7 +47,7 @@ class BasicProvider extends Component {
                 <option value='NMEA2000'>NMEA 2000</option>
                 <option value='NMEA0183'>NMEA 0183</option>
                 <option value='SignalK'>Signal K</option>
-                <option value='Seatalk'>Seatalk</option>
+                <option value='Seatalk'>Seatalk (GPIO)</option>
                 <option value='FileStream'>File Stream</option>
               </Input>
             ) : (

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -25,6 +25,7 @@ class BasicProvider extends Component {
       NMEA2000: NMEA2000,
       NMEA0183: NMEA0183,
       SignalK: SignalK,
+      Seatalk: Seatalk,
       FileStream: FileStream
     }
     let TypeComponent = lookup[this.props.value.type] || (() => null)
@@ -46,6 +47,7 @@ class BasicProvider extends Component {
                 <option value='NMEA2000'>NMEA 2000</option>
                 <option value='NMEA0183'>NMEA 0183</option>
                 <option value='SignalK'>Signal K</option>
+                <option value='Seatalk'>Seatalk</option>
                 <option value='FileStream'>File Stream</option>
               </Input>
             ) : (
@@ -820,6 +822,8 @@ const SignalK = props => {
     </div>
   )
 }
+
+const Seatalk = props => null
 
 const FileStream = props => {
   return (

--- a/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
+++ b/packages/server-admin-ui/src/views/ServerConfig/BasicProvider.js
@@ -823,7 +823,49 @@ const SignalK = props => {
   )
 }
 
-const Seatalk = props => null
+const gpios = [4, 5, 6, 12, 13, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27].map(gpio => `0${gpio}`.slice(-2))
+const Seatalk = props =>
+<span>
+<FormGroup row>
+    <Col md='2'>
+      <Label htmlFor="gpio">GPIO Pin</Label>
+    </Col>
+    <Col xs='12' md='3'>
+      <Input
+        type="select"
+        name="options.gpio"
+        id="gpio"
+        onChange={props.onChange}
+        value={props.value.options.gpio || gpios[0]}
+      >
+      {gpios.map(gpio => <option key={gpio}>{`GPIO${gpio}`}</option>)}
+      </Input>
+    </Col>
+  </FormGroup>
+  <FormGroup row>
+    <Col md='2'>
+      <Label htmlFor="gpioInvert">Invert signal</Label>
+    </Col>
+    <Col xs='12' md='10'>
+        <Label className='switch switch-text switch-primary'>
+          <Input
+            type='checkbox'
+            id='gpioInvert'
+            name='options.gpioInvert'
+            className='switch-input'
+            onChange={props.onChange}
+            checked={props.value.options.gpioInvert}
+          />
+          <span
+            className='switch-label'
+            data-on='Yes'
+            data-off='No'
+          />
+          <span className='switch-handle' />
+        </Label>
+    </Col>
+  </FormGroup>
+</span>
 
 const FileStream = props => {
   return (

--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 function PigpioSeatalk (options) {
   Execute.call(this, {debug})
   this.options = options
-  this.options.command = `python -u -c '${cmd}' --gpio=${options.gpio} --invert=${options.gpioInvert} `
+  this.options.command = `python -u -c '${cmd}' ${options.gpio} ${options.gpioInvert} `
 }
 
 require('util').inherits(PigpioSeatalk, Execute)

--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -15,6 +15,9 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * 
+ * 2020-06-24 Original Python code from @Thomas-GeDaD https://github.com/Thomas-GeDaD/Seatalk1-Raspi-reader
+ * and finetuned by @MatsA
  *
  */
 
@@ -23,7 +26,11 @@ const debug = require('debug')('signalk:streams:pigpio-seatalk')
 
 const cmd = `
 import pigpio, time, signal, sys
-gpio= 19 #define gpio where the seatalk1 (yellow wire) is connected
+
+if  sys.argv[1] == "undefined":
+        gpio = 4					                            #Default GPIO4 if not set
+else:
+        gpio = int(filter(str.isdigit, sys.argv[1])) 	#Ggpio, info as "GPIOnn", from GUI setup. Sensing the seatalk1 (yellow wire)
 
 if __name__ == "__main__":
         st1read =pigpio.pi()
@@ -34,6 +41,10 @@ if __name__ == "__main__":
                 pass
         
         st1read.bb_serial_read_open(gpio, 4800,9)
+
+        if  sys.argv[2] == "true":			        # Invert, inverted input from ST1, selected in the GUI
+                st1read.bb_serial_invert(gpio, 1)
+
         data=""
         
         try:

--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -21,10 +21,42 @@
 const Execute = require('./execute')
 const debug = require('debug')('signalk:streams:pigpio-seatalk')
 
-const cmd = `import time
-while True:
-  print("$STALK,00,02,41,22,22*6A")
-  time.sleep(2.0)
+const cmd = `
+import pigpio, time, signal, sys
+gpio= 19 #define gpio where the seatalk1 (yellow wire) is connected
+
+if __name__ == "__main__":
+        st1read =pigpio.pi()
+        
+        try:
+                st1read.bb_serial_read_close(gpio) #close if already run
+        except:
+                pass
+        
+        st1read.bb_serial_read_open(gpio, 4800,9)
+        data=""
+        
+        try:
+                while True:
+                        out=(st1read.bb_serial_read(gpio))
+                        out0=out[0]
+                        if out0>0:
+                                out_data=out[1]
+                                x=0
+                                while x < out0:
+                                        if out_data[x+1] ==0:
+                                                string1=str(hex(out_data[x]))
+                                                data= data+string1[2:]+ ","
+                                        else:
+                                                data=data[0:-1]
+                                                data="$STALK,"+data
+                                                print (data)
+                                                string2=str(hex(out_data[x]))
+                                                data=string2[2:]+ ","
+                                                x+=2
+        except:
+                st1read.bb_serial_read_close(gpio)
+                print ("exit")
 `
 
 function PigpioSeatalk (options) {

--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -53,7 +53,7 @@ if __name__ == "__main__":
                                                 print (data)
                                                 string2=str(hex(out_data[x]))
                                                 data=string2[2:]+ ","
-                                                x+=2
+                                        x+=2
         except:
                 st1read.bb_serial_read_close(gpio)
                 print ("exit")

--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -62,7 +62,7 @@ if __name__ == "__main__":
 function PigpioSeatalk (options) {
   Execute.call(this, {debug})
   this.options = options
-  this.options.command = `python -u -c '${cmd}'`
+  this.options.command = `python -u -c '${cmd}' --gpio=${options.gpio} --invert=${options.gpioInvert} `
 }
 
 require('util').inherits(PigpioSeatalk, Execute)

--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -1,0 +1,39 @@
+/*
+ *
+ * prototype-server: An implementation of a Signal K server for boats.
+ * Copyright (C) 2020 Teppo Kurki <teppo.kurki@iki.fi> *et al*.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+const Execute = require('./execute')
+const debug = require('debug')('signalk:streams:pigpio-seatalk')
+
+const cmd = `import time
+while True:
+  print("$STALK,00,02,41,22,22*6A")
+  time.sleep(2.0)
+`
+
+function PigpioSeatalk (options) {
+  Execute.call(this, {debug})
+  this.options = options
+  this.options.command = `python -u -c '${cmd}'`
+}
+
+require('util').inherits(PigpioSeatalk, Execute)
+
+
+module.exports = PigpioSeatalk

--- a/packages/streams/simple.js
+++ b/packages/streams/simple.js
@@ -115,7 +115,7 @@ const dataTypeMapping = {
     options.subOptions.type !== 'wss' && options.subOptions.type !== 'ws'
       ? [new FromJson(options.subOptions)]
       : [],
-  Seatalk:  options => [new nmea0183_signalk(options.subOptions)],
+  Seatalk:  options => [new nmea0183_signalk({...options.subOptions, validateChecksum: false})],
   NMEA0183: options => {
     const result = [new nmea0183_signalk(options.subOptions)]
     if (options.type === 'FileStream') {

--- a/packages/streams/simple.js
+++ b/packages/streams/simple.js
@@ -22,6 +22,7 @@ const CanboatJs = require('./canboatjs')
 const iKonvert = require('@canboat/canboatjs').iKonvert
 const Ydwg02 = require('@canboat/canboatjs').Ydwg02
 const gpsd = require('./gpsd')
+const pigpioSeatalk = require('./pigpio-seatalk')
 
 function Simple (options) {
   Transform.call(this, { objectMode: true })
@@ -105,7 +106,8 @@ const discriminatorByDataType = {
   NMEA2000YD: 'A',
   NMEA2000: 'A',
   NMEA0183: 'N',
-  SignalK: 'I'
+  SignalK: 'I',
+  Seatalk: 'N'
 }
 
 const dataTypeMapping = {
@@ -113,6 +115,7 @@ const dataTypeMapping = {
     options.subOptions.type !== 'wss' && options.subOptions.type !== 'ws'
       ? [new FromJson(options.subOptions)]
       : [],
+  Seatalk:  options => [new nmea0183_signalk(options.subOptions)],
   NMEA0183: options => {
     const result = [new nmea0183_signalk(options.subOptions)]
     if (options.type === 'FileStream') {
@@ -178,7 +181,8 @@ const pipeStartByType = {
   NMEA0183: nmea0183input,
   Execute: executeInput,
   FileStream: fileInput,
-  SignalK: signalKInput
+  SignalK: signalKInput,
+  Seatalk: seatalkInput
 }
 
 function nmea2000input (subOptions, logging) {
@@ -322,4 +326,8 @@ function signalKInput (subOptions) {
     return [new serialport(subOptions)]
   }
   throw new Error(`unknown SignalK type: ${subOptions.type}`)
+}
+
+function seatalkInput(subOptions) {
+  return [new pigpioSeatalk(subOptions)]
 }

--- a/raspberry_pi_installation.md
+++ b/raspberry_pi_installation.md
@@ -138,7 +138,17 @@ Check status with;
 
 ## Real inputs
 
-NMEA2000
+Real inputs are configured in ”Server => Connections” where You can choose from the following
+
+Input Type | Remark
+--------- | ---------------------------------------------------------------
+NMEA 2000 | Check possible hardware in the ”NMEA 2000 Source” drop down list
+NMEA 0183 | Check possible sources in the ”NMEA 0183 Source” drop down list
+SignalK | Check possible sources in the ”NMEA 0183 Source” drop down list
+SeaTalk(GPIO) | SeaTalk 1 data via a Raspberry GPIO pin, [documentation here](https://github.com/SignalK/signalk-server-node/blob/seatalk/Seatalk(GPIO).md)
+Filestream |Check possible data types in the ”Data Type” drop down list
+
+**NMEA2000**
 
 If You have a NMEA2000 network You can use the the Actisense interface or other CAN bus interfaces to connect to the SignalK server. To configure it You have to know the the device path. One way to check it, is using the `dmesg` command direct after You plugged in the Actisense to a RPi USB port. In a Terminal window type
 
@@ -177,7 +187,7 @@ The SignalK server **must be restarted** to accept the changes so click on "Rest
 
 After the restart check the data with the Webapp Instrumentpanel in the admin UI.
 
-NMEA0183
+**NMEA0183**
 
 If You have a NMEA0183 network, plug in Your NMEA0183 to USB interface and do the same procedure as for the Actisense above.
 With a configuration maybe looking like this
@@ -190,13 +200,11 @@ If You don’t have any NMEA interface hardware You could set up a "File Stream"
 
 Find the path to NMEA2000 file
 
-    cd /
-    sudo find -name "aava-n2k.data"
+    sudo find / -name "aava-n2k.data"
 
 Or the path to NMEA0183 file 
 
-    cd /
-    sudo find -name "plaka.log"
+    sudo find / -name "plaka.log"
 
 ## NMEA0183 data on the network
 


### PR DESCRIPTION
@MatsA @Thomas-GeDaD here's SK server code that
- adds a new connection type `Seatalk`
- forks a dummy Python process that just prints STALK sentences

So if you can provide a Python script that reads serial and produces STALK output this should work.

![image](https://user-images.githubusercontent.com/1049678/84703203-87e6ea00-af60-11ea-86c3-5bfda406ca3c.png)


If you want to try this branch out you need to performa these steps:
- clone the repo and checkout this branch
- npm install
- compile the server code with `npx tsc`
- cd packages/server-admin-ui
- npm install
- npm build
- npm link
- cd ../..
- npm link @signalk/server-admin-ui
- cd packages/streams
- npm link
- cd ../..
- npm link @signalk/streams

This will link the admin ui and streams packages from the main server and compile the server and the ui so that they work together.
