### PR TITLE
fix: allow retry installing a plugin after it fails

### DIFF
--- a/src/interfaces/appstore.js
+++ b/src/interfaces/appstore.js
@@ -257,6 +257,7 @@ module.exports = function(app) {
           }
         } else if (modulesInstalledSinceStartup[name].code !== 0) {
           pluginInfo.installFailed = true
+          addIfNotDuplicate(result.available, pluginInfo)
         }
         pluginInfo.isRemove = modulesInstalledSinceStartup[name].isRemove
         addIfNotDuplicate(result.installing, pluginInfo)


### PR DESCRIPTION
Currently, if plugin installation fails, the plugin is removed from the Available list it the user cannot try again without restarting the server. This change puts the plugin back in the available list after an install fails.