### PR TITLE
fix: support for token in Authorization: Bearer header

### DIFF
--- a/src/tokensecurity.js
+++ b/src/tokensecurity.js
@@ -630,6 +630,9 @@ module.exports = function(app, config) {
       if (!header) {
         header = req.headers['x-authorization']
       }
+      if (header && header.startsWith('Bearer ')) {
+        return header.substring('Bearer '.length);
+      }
       if (header && header.startsWith('JWT ')) {
         return header.substring('JWT '.length)
       }


### PR DESCRIPTION
The spec says one can provide the token in
Authorization: Bearer <token> header.

https://signalk.org/specification/1.4.0/doc/security.html#websockets-clients