### PR TITLE
feature: debug all server events

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -214,6 +214,22 @@ Server.prototype.start = function() {
   const self = this
   const app = this.app
 
+  const eventDebugs = {}
+  const emit = app.emit
+  app.emit = function(eventName) {
+    if (eventName !== 'serverlog') {
+      let eventDebug = eventDebugs[eventName]
+      if (!eventDebug) {
+        eventDebugs[eventName] = eventDebug = require('debug')(`signalk-server:events:${eventName}`)
+      }
+      if (eventDebug.enabled) {
+        eventDebug([...arguments].slice(1))
+      }
+    }
+    emit.apply(app, arguments)
+  }
+
+
   this.app.intervals = []
 
   this.app.intervals.push(


### PR DESCRIPTION
This adds the ability to debug log all server 'app'
events, useful to see events' data in the server log.
The eventDebugs debug function cache could be used to provide
a popup menu in the UI to select events that the user
wants to see in the server log.

The event debugs are named signalk-server:events:<eventname>