### PR TITLE
Feature: add global error handler

### DIFF
--- a/bin/signalk-server
+++ b/bin/signalk-server
@@ -19,6 +19,10 @@
 const Server = require('../lib')
 const server = new Server()
 
+process.on('uncaughtException', err => {
+  console.error(err)
+})
+
 server.start().catch(err => {
   console.log(err)
   process.exit(-1)

--- a/bin/signalk-server
+++ b/bin/signalk-server
@@ -16,11 +16,10 @@
  * limitations under the License.
 */
 
-var Server = require('../lib');
-var server = new Server();
+const Server = require('../lib')
+const server = new Server()
 
-server.start()
-  .catch(err => {
-    console.log(err)
-    process.exit(-1)
-  })
+server.start().catch(err => {
+  console.log(err)
+  process.exit(-1)
+})


### PR DESCRIPTION
    Now uncaught exceptions crash the server, which makes
    debugging things a bit hard, as the server may be crashing
    so that admin ui is not available and the server log that
    way even less so.
    
    This adds a global error handler that simply logs the error.
    This should provide easier access to errors in the server
    log and keep the server up, even if for example a misbehaving
    plugin is not handling its own errors.


For example an interface or a plugin that does somethiing like this 

```
    setTimeout(() => {
      app.emit('error', new Error('crash-u'))
    }, 1000)
```
will cause a crash with 
```
events.js:174
      throw er; // Unhandled 'error' event
      ^
```