### PR TITLE
reducing CPU consumption in seatalk 1

### DIFF
--- a/packages/streams/pigpio-seatalk.js
+++ b/packages/streams/pigpio-seatalk.js
@@ -65,6 +65,7 @@ if __name__ == "__main__":
                                                 string2=str(hex(out_data[x]))
                                                 data=string2[2:]+ ","
                                         x+=2
+                        time.sleep(0.01)
         except:
                 st1read.bb_serial_read_close(gpio)
                 print ("exit")


### PR DESCRIPTION
This change reduces CPU usage from 100% to less than 10%.
Some background: https://forum.openmarine.net/showthread.php?tid=2774&pid=15489#pid15489